### PR TITLE
Add CustomContext::getScale()

### DIFF
--- a/src/Context/CustomContext.php
+++ b/src/Context/CustomContext.php
@@ -72,4 +72,14 @@ final class CustomContext implements Context
     {
         return true;
     }
+
+    /**
+     * Returns the scale used by this context.
+     *
+     * @return int
+     */
+    public function getScale() : int
+    {
+        return $this->scale;
+    }
 }


### PR DESCRIPTION
The motivation behind this is to be able to serialize the Money object and its context and later recreate it to the original version without losing information. We're using our own serialization code and we have a lot of Monies here and there being serialized and unserialized, so we'd like to avoid using reflection.

This is just an initial kick off, I'm looking forward to hearing your thoughts on this.