### PR TITLE
Improve assertion equals and ProviderChainTest

### DIFF
--- a/tests/ExchangeRateProvider/CachedProviderTest.php
+++ b/tests/ExchangeRateProvider/CachedProviderTest.php
@@ -19,21 +19,21 @@ class CachedProviderTest extends AbstractTestCase
         $provider = new CachedProvider($mock);
 
         $this->assertSame(1.1, $provider->getExchangeRate('EUR', 'USD'));
-        $this->assertEquals(1, $mock->getCalls());
+        $this->assertSame(1, $mock->getCalls());
 
         $this->assertSame(1.1, $provider->getExchangeRate('EUR', 'USD'));
-        $this->assertEquals(1, $mock->getCalls());
+        $this->assertSame(1, $mock->getCalls());
 
         $this->assertSame(0.9, $provider->getExchangeRate('EUR', 'GBP'));
-        $this->assertEquals(2, $mock->getCalls());
+        $this->assertSame(2, $mock->getCalls());
 
         $this->assertSame(0.9, $provider->getExchangeRate('EUR', 'GBP'));
-        $this->assertEquals(2, $mock->getCalls());
+        $this->assertSame(2, $mock->getCalls());
 
         $provider->invalidate();
 
         $this->assertSame(0.9, $provider->getExchangeRate('EUR', 'GBP'));
-        $this->assertEquals(3, $mock->getCalls());
+        $this->assertSame(3, $mock->getCalls());
     }
 
     public function testGetExchangeRateOfUnknownCurrencyPair() : void

--- a/tests/ExchangeRateProvider/ProviderChainTest.php
+++ b/tests/ExchangeRateProvider/ProviderChainTest.php
@@ -2,11 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Brick\Money\Tests;
+namespace Brick\Money\Tests\ExchangeRateProvider;
 
 use Brick\Money\ExchangeRateProvider;
 use Brick\Money\ExchangeRateProvider\ConfigurableProvider;
 use Brick\Money\ExchangeRateProvider\ProviderChain;
+use Brick\Money\Tests\AbstractTestCase;
 
 /**
  * Tests for class ProviderChain.


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to make value equals assertion strict.
- The `ProviderChainTest.php` class should change into `Brick\Money\Tests\ExchangeRateProvider` namespace.