### PR TITLE
Skip intl tests if extenstion is not installed

### DIFF
--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -860,6 +860,7 @@ class MoneyTest extends AbstractTestCase
 
     /**
      * @dataProvider providerFormatWith
+     * @requires extension intl
      *
      * @param array  $money    The money to test.
      * @param string $locale   The target locale.
@@ -888,6 +889,7 @@ class MoneyTest extends AbstractTestCase
 
     /**
      * @dataProvider providerFormatTo
+     * @requires extension intl
      *
      * @param array  $money            The money to test.
      * @param string $locale           The target locale.


### PR DESCRIPTION
Resolve test errors if intl extenstion is not installed 
```There were 12 errors:

1) Brick\Money\Tests\MoneyTest::testFormatTo with data set #0 (array('1.23', 'USD'), 'en_US', false, '$1.23')
Error: Class 'NumberFormatter' not found

/home/doc/projects/_opensource/money/src/Money.php:686
/home/doc/projects/_opensource/money/tests/MoneyTest.php:900
```