### PR TITLE
Reorganize exceptions structure

### DIFF
--- a/src/Exception/CurrencyConversionException.php
+++ b/src/Exception/CurrencyConversionException.php
@@ -7,7 +7,7 @@ namespace Brick\Money\Exception;
 /**
  * Exception thrown when an exchange rate is not available.
  */
-class CurrencyConversionException extends MoneyException
+class CurrencyConversionException extends \RuntimeException implements MoneyException
 {
     /**
      * @var string

--- a/src/Exception/MoneyException.php
+++ b/src/Exception/MoneyException.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Brick\Money\Exception;
 
 /**
- * Base class for money exceptions.
+ * Interface for money exceptions.
  */
-abstract class MoneyException extends \Exception
+interface MoneyException extends \Throwable
 {
 }

--- a/src/Exception/MoneyMismatchException.php
+++ b/src/Exception/MoneyMismatchException.php
@@ -9,7 +9,7 @@ use Brick\Money\Currency;
 /**
  * Exception thrown when a money is not in the expected currency or context.
  */
-class MoneyMismatchException extends MoneyException
+class MoneyMismatchException extends \DomainException implements MoneyException
 {
     /**
      * @param Currency $expected

--- a/src/Exception/UnknownCurrencyException.php
+++ b/src/Exception/UnknownCurrencyException.php
@@ -7,7 +7,7 @@ namespace Brick\Money\Exception;
 /**
  * Exception thrown when attempting to create a Currency from an unknown currency code.
  */
-class UnknownCurrencyException extends MoneyException
+class UnknownCurrencyException extends \DomainException implements MoneyException
 {
     /**
      * @param string|int $currencyCode


### PR DESCRIPTION
Usually exceptions divide into checked and unchecked. It is more [java concept](https://crunchify.com/better-understanding-on-checked-vs-unchecked-exceptions-how-to-handle-exception-better-way-in-java/), but also suitable for php world.

When `\LogicException` (unchecked) arises you don't usually want to catch and continue to work, better way is just show some error and fail fast. Because this exception means some bug in source code and only good way to deal with it - fix this bug.  
This is the reason why [phpstorm skips](https://blog.jetbrains.com/phpstorm/2018/04/configurable-unchecked-exceptions/) `\LogicException` by default.

My proposal is reorganisation money exceptions structure to make `MoneyMismatchException` and `UnknownCurrencyException` unchecked by extending `\LogicException`.

Before:
![image](https://user-images.githubusercontent.com/1427813/96341965-e99b9a00-10a1-11eb-9fb2-eaa805d8ae00.png)
What should I do? Write useless try-catch, or add `@throws` annotation (which will be a lie)

After:
![image](https://user-images.githubusercontent.com/1427813/96341649-d38dd980-10a1-11eb-9822-d52172d1b5bd.png)
Phpstorm just skips this exception check.



**Be aware, this changes is not really backward compatible!**