### PR TITLE
Make BaseCurrencyProvider always return BigNumber

### DIFF
--- a/src/ExchangeRateProvider/BaseCurrencyProvider.php
+++ b/src/ExchangeRateProvider/BaseCurrencyProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Brick\Money\ExchangeRateProvider;
 
+use Brick\Math\BigNumber;
 use Brick\Money\ExchangeRateProvider;
 
 use Brick\Math\BigRational;
@@ -49,7 +50,7 @@ final class BaseCurrencyProvider implements ExchangeRateProvider
     public function getExchangeRate(string $sourceCurrencyCode, string $targetCurrencyCode)
     {
         if ($sourceCurrencyCode === $this->baseCurrencyCode) {
-            return $this->provider->getExchangeRate($sourceCurrencyCode, $targetCurrencyCode);
+            return BigNumber::of($this->provider->getExchangeRate($sourceCurrencyCode, $targetCurrencyCode));
         }
 
         if ($targetCurrencyCode === $this->baseCurrencyCode) {

--- a/src/ExchangeRateProvider/BaseCurrencyProvider.php
+++ b/src/ExchangeRateProvider/BaseCurrencyProvider.php
@@ -47,7 +47,7 @@ final class BaseCurrencyProvider implements ExchangeRateProvider
     /**
      * {@inheritdoc}
      */
-    public function getExchangeRate(string $sourceCurrencyCode, string $targetCurrencyCode)
+    public function getExchangeRate(string $sourceCurrencyCode, string $targetCurrencyCode): BigNumber
     {
         if ($sourceCurrencyCode === $this->baseCurrencyCode) {
             return BigNumber::of($this->provider->getExchangeRate($sourceCurrencyCode, $targetCurrencyCode));

--- a/tests/ExchangeRateProvider/BaseCurrencyProviderTest.php
+++ b/tests/ExchangeRateProvider/BaseCurrencyProviderTest.php
@@ -65,7 +65,7 @@ class BaseCurrencyProviderTest extends AbstractTestCase
     /**
      * @dataProvider providerReturnBigNumber
      *
-     * @param  BigNumber|float|int|string $rate
+     * @param BigNumber|float|int|string $rate
      */
     public function testReturnBigNumber($rate) : void
     {

--- a/tests/ExchangeRateProvider/BaseCurrencyProviderTest.php
+++ b/tests/ExchangeRateProvider/BaseCurrencyProviderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Brick\Money\Tests\ExchangeRateProvider;
 
+use Brick\Math\BigNumber;
 use Brick\Money\ExchangeRateProvider;
 use Brick\Money\ExchangeRateProvider\BaseCurrencyProvider;
 use Brick\Money\ExchangeRateProvider\ConfigurableProvider;
@@ -38,7 +39,7 @@ class BaseCurrencyProviderTest extends AbstractTestCase
     public function testGetExchangeRate(string $sourceCurrencyCode, string $targetCurrencyCode, string $exchangeRate) : void
     {
         $rate = $this->getExchangeRateProvider()->getExchangeRate($sourceCurrencyCode, $targetCurrencyCode);
-        self::assertSame($exchangeRate, (string) BigRational::of($rate)->toScale(6, RoundingMode::DOWN));
+        self::assertSame($exchangeRate, (string) $rate->toScale(6, RoundingMode::DOWN));
     }
 
     public function providerGetExchangeRate() : array
@@ -59,5 +60,26 @@ class BaseCurrencyProviderTest extends AbstractTestCase
             ['CAD', 'EUR', '0.818181'],
             ['CAD', 'GBP', '0.727272'],
         ];
+    }
+
+    /**
+     * @dataProvider providerExchangeRateType
+     *
+     * @param  BigNumber|float|int|string      $rate
+     */
+    public function testReturnBigNumber($rate)
+    {
+        $configurableProvider = new ConfigurableProvider();
+        $configurableProvider->setExchangeRate('USD', 'EUR', $rate);
+        $baseProvider = new BaseCurrencyProvider($configurableProvider, 'USD');
+
+        $rate = $baseProvider->getExchangeRate('USD', 'EUR');
+
+        $this->assertEquals(BigNumber::of($rate), $rate);
+    }
+
+    public function providerExchangeRateType()
+    {
+        return [[1], [1.1], ['1.0'], [BigNumber::of('1')]];
     }
 }

--- a/tests/ExchangeRateProvider/BaseCurrencyProviderTest.php
+++ b/tests/ExchangeRateProvider/BaseCurrencyProviderTest.php
@@ -75,7 +75,7 @@ class BaseCurrencyProviderTest extends AbstractTestCase
 
         $rate = $baseProvider->getExchangeRate('USD', 'EUR');
 
-        $this->assertEquals(BigNumber::of($rate), $rate);
+        $this->assertInstanceOf(BigNumber::class, $rate);
     }
 
     public function providerReturnBigNumber() : array

--- a/tests/ExchangeRateProvider/BaseCurrencyProviderTest.php
+++ b/tests/ExchangeRateProvider/BaseCurrencyProviderTest.php
@@ -65,9 +65,9 @@ class BaseCurrencyProviderTest extends AbstractTestCase
     /**
      * @dataProvider providerReturnBigNumber
      *
-     * @param  BigNumber|float|int|string      $rate
+     * @param  BigNumber|float|int|string $rate
      */
-    public function testReturnBigNumber($rate)
+    public function testReturnBigNumber($rate) : void
     {
         $configurableProvider = new ConfigurableProvider();
         $configurableProvider->setExchangeRate('USD', 'EUR', $rate);
@@ -78,7 +78,7 @@ class BaseCurrencyProviderTest extends AbstractTestCase
         $this->assertEquals(BigNumber::of($rate), $rate);
     }
 
-    public function providerReturnBigNumber()
+    public function providerReturnBigNumber() : array
     {
         return [[1], [1.1], ['1.0'], [BigNumber::of('1')]];
     }

--- a/tests/ExchangeRateProvider/BaseCurrencyProviderTest.php
+++ b/tests/ExchangeRateProvider/BaseCurrencyProviderTest.php
@@ -63,7 +63,7 @@ class BaseCurrencyProviderTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider providerExchangeRateType
+     * @dataProvider providerReturnBigNumber
      *
      * @param  BigNumber|float|int|string      $rate
      */
@@ -78,7 +78,7 @@ class BaseCurrencyProviderTest extends AbstractTestCase
         $this->assertEquals(BigNumber::of($rate), $rate);
     }
 
-    public function providerExchangeRateType()
+    public function providerReturnBigNumber()
     {
         return [[1], [1.1], ['1.0'], [BigNumber::of('1')]];
     }


### PR DESCRIPTION
When using `BaseCurrencyProvider` with another provider that doesn't store exchange rates as `BigNumber`, the return type is inconsistent between the original exchange rate and its reciprocal. 

```php
$configurableProvider = new ConfigurableProvider();
$configurableProvider->setExchangeRate('USD', 'EUR', 1.2);
$baseProvider = new BaseCurrencyProvider($configurableProvider, 'USD');

// Returns float
$rate = $baseProvider->getExchangeRate('USD', 'EUR');

// Returns BigNumber
$rate = $baseProvider->getExchangeRate('EUR', 'USD');
```

I can see the value in being able to store and return rates as float/int/string in other providers if you choose, but in this case you'll always get a type mismatch on reciprocals unless you're storing as `BigNumber`. To make things more consistent, this PR converts all rates to `BigNumber` when returning from `BaseCurrencyProvider`.

Note this is a breaking change.