### PR TITLE
update "Using an ORM" example for better typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,7 +439,10 @@ If you're using an ORM such as Doctrine, it is advised to store the amount and c
   ```php
   class Entity
   {
-      private int $price;
+      /** @ORM\Column(type="bigint") */
+      private string $price;
+
+      /** @ORM\Column(type="string", length=3) */
       private string $currencyCode;
 
       public function getPrice() : Money
@@ -449,7 +452,7 @@ If you're using an ORM such as Doctrine, it is advised to store the amount and c
 
       public function setPrice(Money $price) : void
       {
-          $this->price = $price->getMinorAmount()->toInt();
+          $this->price = (string) $price->getMinorAmount();
           $this->currencyCode = $price->getCurrency()->getCurrencyCode();
       }
   }


### PR DESCRIPTION
update "Using an ORM" example for better typing

 - add doctrine orm types, using `bigint` as the amount
 - use `string` as the property type

It is important to use `string` as the property type with `bigint`, as this is the type
that will be returned by the RDBMS. If `int` is used, Doctrine will
always compute a diff in the price field, issuing a useless update from
 "100" (string) to 100 (int).