### PR TITLE
Update an example of $converter->convert() in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ $exchangeRateProvider = ...;
 $converter = new CurrencyConverter($exchangeRateProvider); // optionally provide a Context here
 
 $money = Money::of('50', 'USD');
-$converter->convert($money, 'EUR', RoundingMode::DOWN);
+$converter->convert($money, 'EUR', null, RoundingMode::DOWN);
 ```
 
 The converter performs the most precise calculation possible, internally representing the result as a rational number until the very last step.


### PR DESCRIPTION
Since version 0.6.0 (https://github.com/brick/money/commit/c82e10618719b9ef4f57a9d3531a7a433d901138) the `convert()` method signature has changed. However, readme was not updated and throws an error: 
> ... Argument # 3 ($context) must be of type ?Brick\Money\Context ...

Since PHP 8.0 (named function arguments) we could use `$converter->convert($money, 'EUR', roundingMode: RoundingMode::DOWN);`, but the package still supports PHP 7.4, so let's use the `null` in the example.