### PR TITLE
Allow using Money, Currency and Context in Psalm's immutable contexts

### DIFF
--- a/src/AbstractMoney.php
+++ b/src/AbstractMoney.php
@@ -18,6 +18,8 @@ use Stringable;
  *
  * Please consider this class sealed: extending this class yourself is not supported, and breaking changes (such as
  * adding new abstract methods) can happen at any time, even in a minor version.
+ *
+ * @psalm-immutable
  */
 abstract class AbstractMoney implements MoneyContainer, Stringable, JsonSerializable
 {

--- a/src/Context.php
+++ b/src/Context.php
@@ -11,6 +11,8 @@ use Brick\Math\RoundingMode;
 
 /**
  * Adjusts a rational number to a decimal amount.
+ *
+ * @psalm-immutable
  */
 interface Context
 {

--- a/src/Context/AutoContext.php
+++ b/src/Context/AutoContext.php
@@ -13,6 +13,8 @@ use Brick\Math\RoundingMode;
 
 /**
  * Automatically adjusts the scale of a number to the strict minimum.
+ *
+ * @psalm-immutable
  */
 final class AutoContext implements Context
 {

--- a/src/Context/CashContext.php
+++ b/src/Context/CashContext.php
@@ -12,6 +12,8 @@ use Brick\Math\BigNumber;
 
 /**
  * Adjusts a number to the default scale for the currency, respecting a cash rounding.
+ *
+ * @psalm-immutable
  */
 final class CashContext implements Context
 {

--- a/src/Context/CustomContext.php
+++ b/src/Context/CustomContext.php
@@ -12,6 +12,8 @@ use Brick\Math\BigNumber;
 
 /**
  * Adjusts a number to a custom scale, and optionally step.
+ *
+ * @psalm-immutable
  */
 final class CustomContext implements Context
 {

--- a/src/Context/DefaultContext.php
+++ b/src/Context/DefaultContext.php
@@ -12,6 +12,8 @@ use Brick\Math\BigNumber;
 
 /**
  * Adjusts a number to the default scale for the currency.
+ *
+ * @psalm-immutable
  */
 final class DefaultContext implements Context
 {

--- a/src/Currency.php
+++ b/src/Currency.php
@@ -9,6 +9,8 @@ use Stringable;
 
 /**
  * A currency. This class is immutable.
+ *
+ * @psalm-immutable
  */
 final class Currency implements Stringable
 {

--- a/src/RationalMoney.php
+++ b/src/RationalMoney.php
@@ -15,6 +15,8 @@ use Brick\Math\Exception\MathException;
  *
  * This is used to represent intermediate calculation results, and may not be exactly convertible to a decimal amount
  * with a finite number of digits. The final conversion to a Money may require rounding.
+ *
+ * @psalm-immutable
  */
 final class RationalMoney extends AbstractMoney
 {


### PR DESCRIPTION
Added `@psalm-immutable` and `@psalm-pure` annotations to appropriate classes and static methods.

I took some shortcuts: for example, for the places where \NumberFormatter is used, `psalm-suppress` annotations was required.

Also, unfortunately, `Currency::of()` is using `ISOCurrencyProvider` which is heavily impure internally, therefore all static methods using `Currency::of()` were not marked as pure. Even more unfortunate is that one of the `Money`'s non-static method is using `Currency::of()` and it had to be marked  I am not sure what to do about this.