### PR TITLE
Exclude development files from releases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,9 @@
 .gitignore            export-ignore
 import-currencies.php export-ignore
 phpunit.xml           export-ignore
+psalm.xml             export-ignore
 README.md             export-ignore
+.github/              export-ignore
 tests/                export-ignore
 
 *.php diff=php


### PR DESCRIPTION
This PR makes it so that this repository's GitHub Actions workflows and Psalm configuration aren't included in future releases.