### PR TITLE
Money contracts

### DIFF
--- a/src/AbstractMoney.php
+++ b/src/AbstractMoney.php
@@ -20,7 +20,7 @@ use Stringable;
  * Please consider this class sealed: extending this class yourself is not supported, and breaking changes (such as
  * adding new abstract methods) can happen at any time, even in a minor version.
  */
-abstract class AbstractMoney implements MoneyInterface, MoneyContainer, Monetizable, Stringable, JsonSerializable
+abstract class AbstractMoney implements Monetizable, MoneyContainer, Stringable, JsonSerializable
 {
     abstract public function getAmount() : BigNumber;
 

--- a/src/AbstractMoney.php
+++ b/src/AbstractMoney.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace Brick\Money;
 
+use Brick\Money\Contracts\Monetizable;
+use Brick\Money\Contracts\MoneyInterface;
 use Brick\Money\Exception\MoneyMismatchException;
-
 use Brick\Math\BigNumber;
 use Brick\Math\RoundingMode;
 use Brick\Math\Exception\MathException;
@@ -19,7 +20,7 @@ use Stringable;
  * Please consider this class sealed: extending this class yourself is not supported, and breaking changes (such as
  * adding new abstract methods) can happen at any time, even in a minor version.
  */
-abstract class AbstractMoney implements MoneyContainer, Stringable, JsonSerializable
+abstract class AbstractMoney implements MoneyInterface, MoneyContainer, Monetizable, Stringable, JsonSerializable
 {
     abstract public function getAmount() : BigNumber;
 
@@ -124,7 +125,7 @@ abstract class AbstractMoney implements MoneyContainer, Stringable, JsonSerializ
      * @throws MathException          If the argument is an invalid number.
      * @throws MoneyMismatchException If the argument is a money in a different currency.
      */
-    final public function compareTo(AbstractMoney|BigNumber|int|float|string $that) : int
+    final public function compareTo(MoneyInterface|BigNumber|int|float|string $that) : int
     {
         return $this->getAmount()->compareTo($this->getAmountOf($that));
     }
@@ -135,7 +136,7 @@ abstract class AbstractMoney implements MoneyContainer, Stringable, JsonSerializ
      * @throws MathException          If the argument is an invalid number.
      * @throws MoneyMismatchException If the argument is a money in a different currency.
      */
-    final public function isEqualTo(AbstractMoney|BigNumber|int|float|string $that) : bool
+    final public function isEqualTo(MoneyInterface|BigNumber|int|float|string $that) : bool
     {
         return $this->getAmount()->isEqualTo($this->getAmountOf($that));
     }
@@ -146,7 +147,7 @@ abstract class AbstractMoney implements MoneyContainer, Stringable, JsonSerializ
      * @throws MathException          If the argument is an invalid number.
      * @throws MoneyMismatchException If the argument is a money in a different currency.
      */
-    final public function isLessThan(AbstractMoney|BigNumber|int|float|string $that) : bool
+    final public function isLessThan(MoneyInterface|BigNumber|int|float|string $that) : bool
     {
         return $this->getAmount()->isLessThan($this->getAmountOf($that));
     }
@@ -157,7 +158,7 @@ abstract class AbstractMoney implements MoneyContainer, Stringable, JsonSerializ
      * @throws MathException          If the argument is an invalid number.
      * @throws MoneyMismatchException If the argument is a money in a different currency.
      */
-    final public function isLessThanOrEqualTo(AbstractMoney|BigNumber|int|float|string $that) : bool
+    final public function isLessThanOrEqualTo(MoneyInterface|BigNumber|int|float|string $that) : bool
     {
         return $this->getAmount()->isLessThanOrEqualTo($this->getAmountOf($that));
     }
@@ -168,7 +169,7 @@ abstract class AbstractMoney implements MoneyContainer, Stringable, JsonSerializ
      * @throws MathException          If the argument is an invalid number.
      * @throws MoneyMismatchException If the argument is a money in a different currency.
      */
-    final public function isGreaterThan(AbstractMoney|BigNumber|int|float|string $that) : bool
+    final public function isGreaterThan(MoneyInterface|BigNumber|int|float|string $that) : bool
     {
         return $this->getAmount()->isGreaterThan($this->getAmountOf($that));
     }
@@ -179,7 +180,7 @@ abstract class AbstractMoney implements MoneyContainer, Stringable, JsonSerializ
      * @throws MathException          If the argument is an invalid number.
      * @throws MoneyMismatchException If the argument is a money in a different currency.
      */
-    final public function isGreaterThanOrEqualTo(AbstractMoney|BigNumber|int|float|string $that) : bool
+    final public function isGreaterThanOrEqualTo(MoneyInterface|BigNumber|int|float|string $that) : bool
     {
         return $this->getAmount()->isGreaterThanOrEqualTo($this->getAmountOf($that));
     }
@@ -190,11 +191,11 @@ abstract class AbstractMoney implements MoneyContainer, Stringable, JsonSerializ
      * Unlike isEqualTo(), this method only accepts a money, and returns false if the given money is in another
      * currency, instead of throwing a MoneyMismatchException.
      *
-     * @param AbstractMoney $that
+     * @param MoneyInterface $that
      *
      * @return bool
      */
-    final public function isAmountAndCurrencyEqualTo(AbstractMoney $that) : bool
+    final public function isAmountAndCurrencyEqualTo(MoneyInterface $that) : bool
     {
         return $this->getAmount()->isEqualTo($that->getAmount())
             && $this->getCurrency()->is($that->getCurrency());
@@ -205,13 +206,13 @@ abstract class AbstractMoney implements MoneyContainer, Stringable, JsonSerializ
      *
      * If the parameter is a money, its currency is checked against this money's currency.
      *
-     * @param AbstractMoney|BigNumber|int|float|string $that A money or amount.
+     * @param MoneyInterface|BigNumber|int|float|string $that A money or amount.
      *
      * @throws MoneyMismatchException If currencies don't match.
      */
-    final protected function getAmountOf(AbstractMoney|BigNumber|int|float|string $that): BigNumber|int|float|string
+    final protected function getAmountOf(MoneyInterface|BigNumber|int|float|string $that): BigNumber|int|float|string
     {
-        if ($that instanceof AbstractMoney) {
+        if ($that instanceof MoneyInterface) {
             if (! $that->getCurrency()->is($this->getCurrency())) {
                 throw MoneyMismatchException::currencyMismatch($this->getCurrency(), $that->getCurrency());
             }

--- a/src/Contracts/Monetizable.php
+++ b/src/Contracts/Monetizable.php
@@ -14,7 +14,7 @@ use Brick\Money\Exception\MoneyMismatchException;
  *
  * @author Ang3^ <https://github.com/Ang3>
  */
-interface Monetizable
+interface Monetizable extends MoneyInterface
 {
 	/**
 	 * Returns the sum of this Money and the given amount.

--- a/src/Contracts/Monetizable.php
+++ b/src/Contracts/Monetizable.php
@@ -32,7 +32,7 @@ interface Monetizable
 	 * @param MoneyInterface|BigNumber|int|float|string $that         The money or amount to add.
 	 * @param int                                       $roundingMode An optional RoundingMode constant.
 	 *
-	 * @return $this
+	 * @return self
 	 *
 	 * @throws MathException          If the argument is an invalid number or rounding is necessary.
 	 * @throws MoneyMismatchException If the argument is a money in a different currency or in a different context.
@@ -56,7 +56,7 @@ interface Monetizable
 	 * @param MoneyInterface|BigNumber|int|float|string $that         The money or amount to subtract.
 	 * @param int                                       $roundingMode An optional RoundingMode constant.
 	 *
-	 * @return $this
+	 * @return self
 	 *
 	 * @throws MathException          If the argument is an invalid number or rounding is necessary.
 	 * @throws MoneyMismatchException If the argument is a money in a different currency or in a different context.
@@ -75,7 +75,7 @@ interface Monetizable
 	 * @param BigNumber|int|float|string $that         The multiplier.
 	 * @param int                        $roundingMode An optional RoundingMode constant.
 	 *
-	 * @return $this
+	 * @return self
 	 *
 	 * @throws MathException If the argument is an invalid number or rounding is necessary.
 	 */
@@ -93,7 +93,7 @@ interface Monetizable
 	 * @param BigNumber|int|float|string $that         The divisor.
 	 * @param int                        $roundingMode An optional RoundingMode constant.
 	 *
-	 * @return $this
+	 * @return self
 	 *
 	 * @throws MathException If the argument is an invalid number or is zero, or rounding is necessary.
 	 */
@@ -104,13 +104,13 @@ interface Monetizable
 	 *
 	 * The resulting Money has the same context as this Money.
 	 *
-	 * @return $this
+	 * @return self
 	 */
 	public function abs(): self;
 	/**
 	 * Returns a Money whose value is the negated value of this Money.
 	 *
-	 * @return $this
+	 * @return self
 	 */
 	public function negated() : self;
 

--- a/src/Contracts/Monetizable.php
+++ b/src/Contracts/Monetizable.php
@@ -1,0 +1,213 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brick\Money\Contracts;
+
+use Brick\Math\BigNumber;
+use Brick\Math\Exception\MathException;
+use Brick\Math\RoundingMode;
+use Brick\Money\Exception\MoneyMismatchException;
+
+/**
+ * Interface implemented by objects allowing money operations.
+ *
+ * @author Ang3^ <https://github.com/Ang3>
+ */
+interface Monetizable
+{
+	/**
+	 * Returns the sum of this Money and the given amount.
+	 *
+	 * If the operand is a Money, it must have the same context as this Money, or an exception is thrown.
+	 * This is by design, to ensure that contexts are not mixed accidentally.
+	 * If you do need to add a Money in a different context, you can use `plus($money->toRational())`.
+	 *
+	 * The resulting Money has the same context as this Money. If the result needs rounding to fit this context, a
+	 * rounding mode can be provided. If a rounding mode is not provided and rounding is necessary, an exception is
+	 * thrown.
+	 *
+	 * @psalm-param RoundingMode::* $roundingMode
+	 *
+	 * @param MoneyInterface|BigNumber|int|float|string $that         The money or amount to add.
+	 * @param int                                       $roundingMode An optional RoundingMode constant.
+	 *
+	 * @return $this
+	 *
+	 * @throws MathException          If the argument is an invalid number or rounding is necessary.
+	 * @throws MoneyMismatchException If the argument is a money in a different currency or in a different context.
+	 */
+	public function plus(MoneyInterface|BigNumber|int|float|string $that, int $roundingMode = RoundingMode::UNNECESSARY): self;
+
+
+	/**
+	 * Returns the difference of this Money and the given amount.
+	 *
+	 * If the operand is a Money, it must have the same context as this Money, or an exception is thrown.
+	 * This is by design, to ensure that contexts are not mixed accidentally.
+	 * If you do need to subtract a Money in a different context, you can use `minus($money->toRational())`.
+	 *
+	 * The resulting Money has the same context as this Money. If the result needs rounding to fit this context, a
+	 * rounding mode can be provided. If a rounding mode is not provided and rounding is necessary, an exception is
+	 * thrown.
+	 *
+	 * @psalm-param RoundingMode::* $roundingMode
+	 *
+	 * @param MoneyInterface|BigNumber|int|float|string $that         The money or amount to subtract.
+	 * @param int                                       $roundingMode An optional RoundingMode constant.
+	 *
+	 * @return $this
+	 *
+	 * @throws MathException          If the argument is an invalid number or rounding is necessary.
+	 * @throws MoneyMismatchException If the argument is a money in a different currency or in a different context.
+	 */
+	public function minus(MoneyInterface|BigNumber|int|float|string $that, int $roundingMode = RoundingMode::UNNECESSARY): self;
+
+	/**
+	 * Returns the product of this Money and the given number.
+	 *
+	 * The resulting Money has the same context as this Money. If the result needs rounding to fit this context, a
+	 * rounding mode can be provided. If a rounding mode is not provided and rounding is necessary, an exception is
+	 * thrown.
+	 *
+	 * @psalm-param RoundingMode::* $roundingMode
+	 *
+	 * @param BigNumber|int|float|string $that         The multiplier.
+	 * @param int                        $roundingMode An optional RoundingMode constant.
+	 *
+	 * @return $this
+	 *
+	 * @throws MathException If the argument is an invalid number or rounding is necessary.
+	 */
+	public function multipliedBy(BigNumber|int|float|string $that, int $roundingMode = RoundingMode::UNNECESSARY): self;
+
+	/**
+	 * Returns the result of the division of this Money by the given number.
+	 *
+	 * The resulting Money has the same context as this Money. If the result needs rounding to fit this context, a
+	 * rounding mode can be provided. If a rounding mode is not provided and rounding is necessary, an exception is
+	 * thrown.
+	 *
+	 * @psalm-param RoundingMode::* $roundingMode
+	 *
+	 * @param BigNumber|int|float|string $that         The divisor.
+	 * @param int                        $roundingMode An optional RoundingMode constant.
+	 *
+	 * @return $this
+	 *
+	 * @throws MathException If the argument is an invalid number or is zero, or rounding is necessary.
+	 */
+	public function dividedBy(BigNumber|int|float|string $that, int $roundingMode = RoundingMode::UNNECESSARY): self;
+
+	/**
+	 * Returns a Money whose value is the absolute value of this Money.
+	 *
+	 * The resulting Money has the same context as this Money.
+	 *
+	 * @return $this
+	 */
+	public function abs(): self;
+	/**
+	 * Returns a Money whose value is the negated value of this Money.
+	 *
+	 * @return $this
+	 */
+	public function negated() : self;
+
+	/**
+	 * Compares this money to the given amount.
+	 *
+	 * @return int [-1, 0, 1] if `$this` is less than, equal to, or greater than `$that`.
+	 *
+	 * @throws MathException          If the argument is an invalid number.
+	 * @throws MoneyMismatchException If the argument is a money in a different currency.
+	 */
+	public function compareTo(MoneyInterface|BigNumber|int|float|string $that): int;
+
+	/**
+	 * Returns whether this money is equal to the given amount.
+	 *
+	 * @throws MathException          If the argument is an invalid number.
+	 * @throws MoneyMismatchException If the argument is a money in a different currency.
+	 */
+	public function isEqualTo(MoneyInterface|BigNumber|int|float|string $that): bool;
+
+	/**
+	 * Returns whether this money is less than the given amount.
+	 *
+	 * @throws MathException          If the argument is an invalid number.
+	 * @throws MoneyMismatchException If the argument is a money in a different currency.
+	 */
+	public function isLessThan(MoneyInterface|BigNumber|int|float|string $that): bool;
+
+	/**
+	 * Returns whether this money is less than or equal to the given amount.
+	 *
+	 * @throws MathException          If the argument is an invalid number.
+	 * @throws MoneyMismatchException If the argument is a money in a different currency.
+	 */
+	public function isLessThanOrEqualTo(MoneyInterface|BigNumber|int|float|string $that): bool;
+
+	/**
+	 * Returns whether this money is greater than the given amount.
+	 *
+	 * @throws MathException          If the argument is an invalid number.
+	 * @throws MoneyMismatchException If the argument is a money in a different currency.
+	 */
+	public function isGreaterThan(MoneyInterface|BigNumber|int|float|string $that): bool;
+
+	/**
+	 * Returns whether this money is greater than or equal to the given amount.
+	 *
+	 * @throws MathException          If the argument is an invalid number.
+	 * @throws MoneyMismatchException If the argument is a money in a different currency.
+	 */
+	public function isGreaterThanOrEqualTo(MoneyInterface|BigNumber|int|float|string $that): bool;
+
+	/**
+	 * Returns whether this money's amount and currency are equal to those of the given money.
+	 *
+	 * Unlike isEqualTo(), this method only accepts a money, and returns false if the given money is in another
+	 * currency, instead of throwing a MoneyMismatchException.
+	 *
+	 * @param MoneyInterface $that
+	 *
+	 * @return bool
+	 */
+	public function isAmountAndCurrencyEqualTo(MoneyInterface $that): bool;
+
+	/**
+	 * Returns whether this money has zero value.
+	 *
+	 * @return bool
+	 */
+	public function isZero(): bool;
+
+	/**
+	 * Returns whether this money has a positive value.
+	 *
+	 * @return bool
+	 */
+	public function isPositive(): bool;
+
+	/**
+	 * Returns whether this money has a positive or zero value.
+	 *
+	 * @return bool
+	 */
+	public function isPositiveOrZero(): bool;
+
+	/**
+	 * Returns whether this money has a negative value.
+	 *
+	 * @return bool
+	 */
+	public function isNegative(): bool;
+
+	/**
+	 * Returns whether this money has a negative or zero value.
+	 *
+	 * @return bool
+	 */
+	public function isNegativeOrZero(): bool;
+}

--- a/src/Contracts/MoneyInterface.php
+++ b/src/Contracts/MoneyInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brick\Money\Contracts;
+
+use Brick\Math\BigNumber;
+use Brick\Money\Currency;
+
+/**
+ * Contract interface for all objects representing a money.
+ *
+ * @author Ang3^ <https://github.com/Ang3>
+ */
+interface MoneyInterface
+{
+	/**
+	 * Returns the amount of this Money, as a BigNumber.
+	 *
+	 * @return BigNumber
+	 */
+	public function getAmount(): BigNumber;
+
+	/**
+	 * Returns the Currency of this Money.
+	 *
+	 * @return Currency
+	 */
+	public function getCurrency(): Currency;
+}

--- a/src/Money.php
+++ b/src/Money.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Brick\Money;
 
 use Brick\Money\Context\DefaultContext;
+use Brick\Money\Contracts\MoneyInterface;
 use Brick\Money\Exception\MoneyMismatchException;
 use Brick\Money\Exception\UnknownCurrencyException;
-
 use Brick\Math\BigDecimal;
 use Brick\Math\BigInteger;
 use Brick\Math\BigNumber;
@@ -16,7 +16,6 @@ use Brick\Math\RoundingMode;
 use Brick\Math\Exception\MathException;
 use Brick\Math\Exception\NumberFormatException;
 use Brick\Math\Exception\RoundingNecessaryException;
-use InvalidArgumentException;
 
 /**
  * A monetary value in a given currency. This class is immutable.
@@ -333,7 +332,7 @@ final class Money extends AbstractMoney
      *
      * @psalm-param RoundingMode::* $roundingMode
      *
-     * @param AbstractMoney|BigNumber|int|float|string $that         The money or amount to add.
+     * @param MoneyInterface|BigNumber|int|float|string $that         The money or amount to add.
      * @param int                                      $roundingMode An optional RoundingMode constant.
      *
      * @return Money
@@ -341,7 +340,7 @@ final class Money extends AbstractMoney
      * @throws MathException          If the argument is an invalid number or rounding is necessary.
      * @throws MoneyMismatchException If the argument is a money in a different currency or in a different context.
      */
-    public function plus(AbstractMoney|BigNumber|int|float|string $that, int $roundingMode = RoundingMode::UNNECESSARY) : Money
+    public function plus(MoneyInterface|BigNumber|int|float|string $that, int $roundingMode = RoundingMode::UNNECESSARY) : Money
     {
         $amount = $this->getAmountOf($that);
 
@@ -371,7 +370,7 @@ final class Money extends AbstractMoney
      *
      * @psalm-param RoundingMode::* $roundingMode
      *
-     * @param AbstractMoney|BigNumber|int|float|string $that         The money or amount to subtract.
+     * @param MoneyInterface|BigNumber|int|float|string $that         The money or amount to subtract.
      * @param int                                      $roundingMode An optional RoundingMode constant.
      *
      * @return Money
@@ -379,7 +378,7 @@ final class Money extends AbstractMoney
      * @throws MathException          If the argument is an invalid number or rounding is necessary.
      * @throws MoneyMismatchException If the argument is a money in a different currency or in a different context.
      */
-    public function minus(AbstractMoney|BigNumber|int|float|string $that, int $roundingMode = RoundingMode::UNNECESSARY) : Money
+    public function minus(MoneyInterface|BigNumber|int|float|string $that, int $roundingMode = RoundingMode::UNNECESSARY) : Money
     {
         $amount = $this->getAmountOf($that);
 

--- a/src/RationalMoney.php
+++ b/src/RationalMoney.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace Brick\Money;
 
+use Brick\Math\RoundingMode;
+use Brick\Money\Contracts\MoneyInterface;
 use Brick\Money\Exception\MoneyMismatchException;
-
 use Brick\Math\BigNumber;
 use Brick\Math\BigRational;
 use Brick\Math\Exception\MathException;
@@ -72,14 +73,14 @@ final class RationalMoney extends AbstractMoney
     /**
      * Returns the sum of this RationalMoney and the given amount.
      *
-     * @param AbstractMoney|BigNumber|int|float|string $that The money or amount to add.
+     * @param MoneyInterface|BigNumber|int|float|string $that The money or amount to add.
      *
      * @return RationalMoney
      *
      * @throws MathException          If the argument is not a valid number.
      * @throws MoneyMismatchException If the argument is a money in another currency.
      */
-    public function plus(AbstractMoney|BigNumber|int|float|string $that) : RationalMoney
+    public function plus(MoneyInterface|BigNumber|int|float|string $that, int $roundingMode = RoundingMode::UNNECESSARY) : RationalMoney
     {
         $that = $this->getAmountOf($that);
         $amount = $this->amount->plus($that);
@@ -90,14 +91,14 @@ final class RationalMoney extends AbstractMoney
     /**
      * Returns the difference of this RationalMoney and the given amount.
      *
-     * @param AbstractMoney|BigNumber|int|float|string $that The money or amount to subtract.
+     * @param MoneyInterface|BigNumber|int|float|string $that The money or amount to subtract.
      *
      * @return RationalMoney
      *
      * @throws MathException          If the argument is not a valid number.
      * @throws MoneyMismatchException If the argument is a money in another currency.
      */
-    public function minus(AbstractMoney|BigNumber|int|float|string $that) : RationalMoney
+    public function minus(MoneyInterface|BigNumber|int|float|string $that, int $roundingMode = RoundingMode::UNNECESSARY) : RationalMoney
     {
         $that = $this->getAmountOf($that);
         $amount = $this->amount->minus($that);
@@ -114,7 +115,7 @@ final class RationalMoney extends AbstractMoney
      *
      * @throws MathException If the argument is not a valid number.
      */
-    public function multipliedBy(BigNumber|int|float|string $that) : RationalMoney
+    public function multipliedBy(BigNumber|int|float|string $that, int $roundingMode = RoundingMode::UNNECESSARY) : RationalMoney
     {
         $amount = $this->amount->multipliedBy($that);
 
@@ -130,14 +131,42 @@ final class RationalMoney extends AbstractMoney
      *
      * @throws MathException If the argument is not a valid number.
      */
-    public function dividedBy(BigNumber|int|float|string $that) : RationalMoney
+    public function dividedBy(BigNumber|int|float|string $that, int $roundingMode = RoundingMode::UNNECESSARY) : RationalMoney
     {
         $amount = $this->amount->dividedBy($that);
 
         return new self($amount, $this->currency);
     }
 
-    /**
+	/**
+	 * Returns the absolute value of this money instance.
+	 *
+	 * @return RationalMoney
+	 */
+	public function abs(): RationalMoney
+	{
+		$amount = $this->getAmount();
+
+		if (!$amount->isNegative()) {
+			return $this;
+		}
+
+		$amount = $amount->multipliedBy(-1);
+
+		return new self($amount, $this->getCurrency());
+	}
+
+	/**
+	 * Returns a Money whose value is the negated value of this Money.
+	 *
+	 * @return RationalMoney
+	 */
+	public function negated() : RationalMoney
+	{
+		return new self($this->amount->negated(), $this->currency);
+	}
+
+	/**
      * Returns a copy of this BigRational, with the amount simplified.
      *
      * @return RationalMoney

--- a/tests/RationalMoneyTest.php
+++ b/tests/RationalMoneyTest.php
@@ -151,6 +151,40 @@ class RationalMoneyTest extends AbstractTestCase
         ];
     }
 
+
+	/**
+	 * @dataProvider providerAbs
+	 */
+	public function testAbs(array $money, string $abs) : void
+	{
+		$this->assertRationalMoneyEquals($abs, RationalMoney::of(...$money)->abs());
+	}
+
+	public function providerAbs() : array
+	{
+		return [
+			[['-1', 'EUR'], 'EUR 1'],
+			[['-1', 'EUR', new AutoContext()], 'EUR 1'],
+			[['1.2', 'JPY', new AutoContext()], 'JPY 12/10'],
+		];
+	}
+
+	/**
+	 * @dataProvider providerNegated
+	 */
+	public function testNegated(array $money, string $negated) : void
+	{
+		$this->assertRationalMoneyEquals($negated, RationalMoney::of(...$money)->negated());
+	}
+
+	public function providerNegated() : array
+	{
+		return [
+			[['1.234', 'EUR', new AutoContext()], 'EUR -1234/1000'],
+			[['-2', 'JPY'], 'JPY 2'],
+		];
+	}
+
     /**
      * @dataProvider providerSimplified
      */


### PR DESCRIPTION
Hi,

I suggest this small PR to implement contract interfaces for money objects.

**Contracts interfaces**

- `Contracts\MoneyInterface` : Contract interface for all objects representing a money (amount and currency).
- `Contracts\Monetizable` extends `Contracts\MoneyInterface` : Interface implemented by objects allowing money operations (plus, minus, abs, isZero, ...).

The interface `Contracts\Monetizable` has been implemented to the base class `AbstractMoney`. By this way, both classes `Money` and `RationalMoney` implement both interfaces.

**Compatibility**

For the compatibility of the class `RationalMoney` to the interface `Contracts\Monetizable`:
- Useless rounding mode parameter added for methods `plus` `minus`, `multiplyBy`, `dividedBy` (yes that's not pretty but required by interfaces...).
- Two methods has been added:
  - `RationalMoney::abs()`: Multiply the value by `-1` only if the result is negative.
  - `RationalMoney::negated()`: Exactly the same that the class `Money` with negated value.