### PR TITLE
Add methods to check if money is not equal

### DIFF
--- a/src/AbstractMoney.php
+++ b/src/AbstractMoney.php
@@ -141,6 +141,17 @@ abstract class AbstractMoney implements MoneyContainer, Stringable, JsonSerializ
     }
 
     /**
+     * Returns whether this money is not equal to the given amount.
+     *
+     * @throws MathException          If the argument is an invalid number.
+     * @throws MoneyMismatchException If the argument is a money in a different currency.
+     */
+    final public function isNotEqualTo(AbstractMoney|BigNumber|int|float|string $that) : bool
+    {
+        return ! $this->isEqualTo($that);
+    }
+
+    /**
      * Returns whether this money is less than the given amount.
      *
      * @throws MathException          If the argument is an invalid number.
@@ -198,6 +209,21 @@ abstract class AbstractMoney implements MoneyContainer, Stringable, JsonSerializ
     {
         return $this->getAmount()->isEqualTo($that->getAmount())
             && $this->getCurrency()->is($that->getCurrency());
+    }
+
+    /**
+     * Returns whether this money's amount and currency are not equal to those of the given money.
+     *
+     * Unlike isNotEqualTo(), this method only accepts a money, and returns true if the given money is in another
+     * currency, instead of throwing a MoneyMismatchException.
+     *
+     * @param AbstractMoney $that
+     *
+     * @return bool
+     */
+    final public function isAmountAndCurrencyNotEqualTo(AbstractMoney $that) : bool
+    {
+        return ! $this->isAmountAndCurrencyEqualTo($that);
     }
 
     /**

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -695,6 +695,7 @@ class MoneyTest extends AbstractTestCase
     public function testIsEqualTo(array $a, array $b, int $c) : void
     {
         self::assertSame($c === 0, Money::of(...$a)->isEqualTo(Money::of(...$b)));
+        self::assertSame($c !== 0, Money::of(...$a)->isNotEqualTo(Money::of(...$b)));
     }
 
     public function testIsEqualToOtherCurrency() : void
@@ -781,6 +782,7 @@ class MoneyTest extends AbstractTestCase
     public function testIsAmountAndCurrencyEqualTo(array $a, array $b, bool $c) : void
     {
         self::assertSame($c, Money::of(...$a)->isAmountAndCurrencyEqualTo(Money::of(...$b)));
+        self::assertNotSame($c, Money::of(...$a)->isAmountAndCurrencyNotEqualTo(Money::of(...$b)));
     }
 
     public function providerIsAmountAndCurrencyEqualTo() : \Generator


### PR DESCRIPTION
When you want to check that 2 money objects are not the same, you currently have to do:
```php
! $firstMoney->isEqualTo($secondMoney);
```
This PR adds a reverse method that makes this more readable:
```php
$firstMoney->isNotEqualTo($secondMoney);
```