### PR TITLE
`Currency` should be JSON serializable

### DIFF
--- a/src/AbstractMoney.php
+++ b/src/AbstractMoney.php
@@ -226,7 +226,7 @@ abstract class AbstractMoney implements MoneyContainer, Stringable, JsonSerializ
     {
         return [
             'amount' => (string) $this->getAmount(),
-            'currency' => $this->getCurrency()
+            'currency' => $this->getCurrency()->jsonSerialize()
         ];
     }
 }

--- a/src/AbstractMoney.php
+++ b/src/AbstractMoney.php
@@ -226,7 +226,7 @@ abstract class AbstractMoney implements MoneyContainer, Stringable, JsonSerializ
     {
         return [
             'amount' => (string) $this->getAmount(),
-            'currency' => (string) $this->getCurrency()
+            'currency' => $this->getCurrency()
         ];
     }
 }

--- a/src/Currency.php
+++ b/src/Currency.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace Brick\Money;
 
 use Brick\Money\Exception\UnknownCurrencyException;
+use JsonSerializable;
 use Stringable;
 
 /**
  * A currency. This class is immutable.
  */
-final class Currency implements Stringable
+final class Currency implements Stringable, JsonSerializable
 {
     /**
      * The currency code.
@@ -164,6 +165,11 @@ final class Currency implements Stringable
 
         return $this->currencyCode === (string) $currency
             || ($this->numericCode !== 0 && $this->numericCode === (int) $currency);
+    }
+
+    final public function jsonSerialize(): array
+    {
+        return $this->currencyCode;
     }
 
     /**

--- a/src/Currency.php
+++ b/src/Currency.php
@@ -167,7 +167,7 @@ final class Currency implements Stringable, JsonSerializable
             || ($this->numericCode !== 0 && $this->numericCode === (int) $currency);
     }
 
-    final public function jsonSerialize(): array
+    final public function jsonSerialize(): string
     {
         return $this->currencyCode;
     }

--- a/tests/CurrencyTest.php
+++ b/tests/CurrencyTest.php
@@ -127,7 +127,7 @@ class CurrencyTest extends AbstractTestCase
     /**
      * @dataProvider providerJsonSerialize
      */
-    public function testJsonSerialize(Currency $currency, array $expected): void
+    public function testJsonSerialize(Currency $currency, string $expected): void
     {
         self::assertSame($expected, $currency->jsonSerialize());
         self::assertSame(json_encode($expected), json_encode($currency));

--- a/tests/CurrencyTest.php
+++ b/tests/CurrencyTest.php
@@ -127,10 +127,10 @@ class CurrencyTest extends AbstractTestCase
     /**
      * @dataProvider providerJsonSerialize
      */
-    public function testJsonSerialize(Currency currency, array $expected): void
+    public function testJsonSerialize(Currency $currency, array $expected): void
     {
-        self::assertSame($expected, currency->jsonSerialize());
-        self::assertSame(json_encode($expected), json_encode(currency));
+        self::assertSame($expected, $currency->jsonSerialize());
+        self::assertSame(json_encode($expected), json_encode($currency));
     }
 
     public function providerJsonSerialize(): array

--- a/tests/CurrencyTest.php
+++ b/tests/CurrencyTest.php
@@ -123,4 +123,20 @@ class CurrencyTest extends AbstractTestCase
         self::assertNotSame($currency, $clone);
         self::assertTrue($clone->is($currency));
     }
+
+    /**
+     * @dataProvider providerJsonSerialize
+     */
+    public function testJsonSerialize(Currency currency, array $expected): void
+    {
+        self::assertSame($expected, currency->jsonSerialize());
+        self::assertSame(json_encode($expected), json_encode(currency));
+    }
+
+    public function providerJsonSerialize(): array
+    {
+        return [
+            [Currency::of('USD'), 'USD']
+        ];
+    }
 }


### PR DESCRIPTION
We regularly pass the currency along to an API as part of an array and expected `Currency` to serialize to a JSON string because it's stringable. However, it serializes to an empty array.

v0.7.0 made `AbstractMoney` JSON serializable, but `Currency` wasn't treated that way.

This updates `Currency` to be JSON serializable when using it separately from `Money`.