### PR TITLE
Allows custom Currency Provider through inheritance

### DIFF
--- a/crypto-currency-provider.php
+++ b/crypto-currency-provider.php
@@ -1,0 +1,43 @@
+<?php
+
+use Brick\Money\Exception\UnknownCurrencyException;
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+class CryptoCurrencyProvider implements \Brick\Money\CurrencyProviderInterface
+{
+
+    public function getCurrency(string $currencyCode): \Brick\Money\Currency
+    {
+        $cryptoCurrency = [
+            'BTC' => new \Brick\Money\Currency('BTC', 0, 'Bitcoin', 8 ),
+        ];
+
+        return $cryptoCurrency[$currencyCode] ?? throw UnknownCurrencyException::unknownCurrency($currencyCode);
+    }
+
+    public function getCurrencyForCountry(string $currencyCode): \Brick\Money\Currency
+    {
+        throw new UnknownCurrencyException('Crypto Currency don\'t have a country code.');
+    }
+}
+
+class CryptoCurrency extends \Brick\Money\Currency {
+    protected static function getCurrencyProvider(): \Brick\Money\CurrencyProviderInterface
+    {
+        return new CryptoCurrencyProvider();
+    }
+}
+
+\Brick\Money\Money::of(2, CryptoCurrency::of('BTC'));
+\Brick\Money\Money::of(2, \Brick\Money\Currency::of('EUR'));
+
+class CryptoMoney extends \Brick\Money\Money {
+    protected static function getCurrencyProvider(): \Brick\Money\CurrencyProviderInterface
+    {
+        return new CryptoCurrencyProvider();
+    }
+}
+
+CryptoMoney::of(2, 'BTC')->plus(CryptoMoney::of(2, 'BTC'));
+CryptoMoney::of(2, 'BTC')->plus(\Brick\Money\Money::of(2, \Brick\Money\Currency::of('EUR')));

--- a/src/Currency.php
+++ b/src/Currency.php
@@ -11,7 +11,7 @@ use Stringable;
 /**
  * A currency. This class is immutable.
  */
-final class Currency implements Stringable, JsonSerializable
+class Currency implements Stringable, JsonSerializable
 {
     /**
      * The currency code.
@@ -71,6 +71,11 @@ final class Currency implements Stringable, JsonSerializable
         $this->defaultFractionDigits = $defaultFractionDigits;
     }
 
+    protected static function getCurrencyProvider() : CurrencyProviderInterface
+    {
+        return ISOCurrencyProvider::getInstance();
+    }
+
     /**
      * Returns a Currency instance matching the given ISO currency code.
      *
@@ -80,7 +85,7 @@ final class Currency implements Stringable, JsonSerializable
      */
     public static function of(string|int $currencyCode) : Currency
     {
-        return ISOCurrencyProvider::getInstance()->getCurrency($currencyCode);
+        return static::getCurrencyProvider()->getCurrency($currencyCode);
     }
 
     /**
@@ -94,7 +99,7 @@ final class Currency implements Stringable, JsonSerializable
      */
     public static function ofCountry(string $countryCode) : Currency
     {
-        return ISOCurrencyProvider::getInstance()->getCurrencyForCountry($countryCode);
+        return static::getCurrencyProvider()->getCurrencyForCountry($countryCode);
     }
 
     /**

--- a/src/CurrencyProviderInterface.php
+++ b/src/CurrencyProviderInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Brick\Money;
+
+use Brick\Money\Exception\UnknownCurrencyException;
+
+interface CurrencyProviderInterface
+{
+    /**
+     * @throws UnknownCurrencyException If an unknown currency code is given.
+     */
+    public function getCurrency(string $currencyCode): Currency;
+
+    /**
+     * @throws UnknownCurrencyException If the country code is unknown, or there is no single currency for the country.
+     */
+    public function getCurrencyForCountry(string $currencyCode): Currency;
+}

--- a/src/ISOCurrencyProvider.php
+++ b/src/ISOCurrencyProvider.php
@@ -9,7 +9,7 @@ use Brick\Money\Exception\UnknownCurrencyException;
 /**
  * Provides ISO 4217 currencies.
  */
-final class ISOCurrencyProvider
+final class ISOCurrencyProvider implements CurrencyProviderInterface
 {
     private static ?ISOCurrencyProvider $instance = null;
 

--- a/src/Money.php
+++ b/src/Money.php
@@ -31,7 +31,7 @@ use InvalidArgumentException;
  * - CustomContext handles monies with a custom scale, and optionally step.
  * - AutoContext automatically adjusts the scale of the money to the minimum required.
  */
-final class Money extends AbstractMoney
+class Money extends AbstractMoney
 {
     /**
      * The amount.
@@ -181,7 +181,7 @@ final class Money extends AbstractMoney
         RoundingMode $roundingMode = RoundingMode::UNNECESSARY,
     ) : Money {
         if (! $currency instanceof Currency) {
-            $currency = Currency::of($currency);
+            $currency = static::getCurrencyProvider()->getCurrency($currency);
         }
 
         if ($context === null) {
@@ -191,6 +191,11 @@ final class Money extends AbstractMoney
         $amount = BigNumber::of($amount);
 
         return self::create($amount, $currency, $context, $roundingMode);
+    }
+
+    protected static function getCurrencyProvider() : CurrencyProviderInterface
+    {
+        return ISOCurrencyProvider::getInstance();
     }
 
     /**
@@ -219,7 +224,7 @@ final class Money extends AbstractMoney
         RoundingMode $roundingMode = RoundingMode::UNNECESSARY,
     ) : Money {
         if (! $currency instanceof Currency) {
-            $currency = Currency::of($currency);
+            $currency = static::getCurrencyProvider()->getCurrency($currency);
         }
 
         if ($context === null) {
@@ -245,7 +250,7 @@ final class Money extends AbstractMoney
     public static function zero(Currency|string|int $currency, ?Context $context = null) : Money
     {
         if (! $currency instanceof Currency) {
-            $currency = Currency::of($currency);
+            $currency = static::getCurrencyProvider()->getCurrency($currency);
         }
 
         if ($context === null) {
@@ -729,7 +734,7 @@ final class Money extends AbstractMoney
         RoundingMode $roundingMode = RoundingMode::UNNECESSARY,
     ) : Money {
         if (! $currency instanceof Currency) {
-            $currency = Currency::of($currency);
+            $currency = static::getCurrencyProvider()->getCurrency($currency);
         }
 
         if ($context === null) {


### PR DESCRIPTION
This is a minimal proof of concept for https://github.com/brick/money/issues/30 and https://github.com/brick/money/issues/61

It uses inheritance as a point of extension for custom logic.

Pros are that existing userland logic will still work as expected while allowing flexibility for more complex use cases.

However extending through composition would be much more robust but would require a profound rewrite of current classes.