### PR TITLE
feat: narrow types

### DIFF
--- a/src/AbstractMoney.php
+++ b/src/AbstractMoney.php
@@ -76,7 +76,7 @@ abstract readonly class AbstractMoney implements Monetary, Stringable, JsonSeria
     /**
      * Returns the sign of this money.
      *
-     * @return int -1 if the number is negative, 0 if zero, 1 if positive.
+     * @return -1|0|1 -1 if the number is negative, 0 if zero, 1 if positive.
      */
     final public function getSign(): int
     {
@@ -126,7 +126,7 @@ abstract readonly class AbstractMoney implements Monetary, Stringable, JsonSeria
     /**
      * Compares this money to the given amount.
      *
-     * @return int [-1, 0, 1] if `$this` is less than, equal to, or greater than `$that`.
+     * @return -1|0|1 If `$this` is less than, equal to, or greater than `$that`.
      *
      * @throws MathException          If the argument is an invalid number.
      * @throws MoneyMismatchException If the argument is a money in a different currency.

--- a/src/Context.php
+++ b/src/Context.php
@@ -35,7 +35,7 @@ interface Context
      * If no cash rounding is involved, this must return 1.
      * This value is used by money allocation methods that do not go through the applyTo() method.
      *
-     * @return int<1, max>
+     * @return positive-int
      */
     public function getStep(): int;
 

--- a/src/Context/CashContext.php
+++ b/src/Context/CashContext.php
@@ -17,8 +17,8 @@ use Override;
 final readonly class CashContext implements Context
 {
     /**
-     * @param int<1, max> $step The cash rounding step, in minor units. Must be a multiple of 2 and/or 5.
-     *                          For example, step 5 on CHF would allow CHF 0.00, CHF 0.05, CHF 0.10, etc.
+     * @param positive-int $step The cash rounding step, in minor units. Must be a multiple of 2 and/or 5.
+     *                           For example, step 5 on CHF would allow CHF 0.00, CHF 0.05, CHF 0.10, etc.
      */
     public function __construct(
         private int $step,

--- a/src/Context/CustomContext.php
+++ b/src/Context/CustomContext.php
@@ -22,7 +22,7 @@ final readonly class CustomContext implements Context
 {
     /**
      * @param non-negative-int $scale The scale of the monies using this context.
-     * @param int<1, max>      $step  An optional cash rounding step. Must either divide 10^scale or be a multiple of 10^scale.
+     * @param positive-int     $step  An optional cash rounding step. Must either divide 10^scale or be a multiple of 10^scale.
      *                                For example, scale=2 and step=5 allows 0.00, 0.05, 0.10, etc.
      *                                And scale=2 and step=1000 allows 0.00, 10.00, 20.00, etc.
      */
@@ -68,6 +68,8 @@ final readonly class CustomContext implements Context
 
     /**
      * Returns the scale used by this context.
+     *
+     * @return non-negative-int
      */
     public function getScale(): int
     {
@@ -76,7 +78,7 @@ final readonly class CustomContext implements Context
 
     /**
      * @param non-negative-int $scale
-     * @param int<1, max>      $step
+     * @param positive-int     $step
      */
     private function isValidStepForScale(int $scale, int $step): bool
     {

--- a/src/Currency.php
+++ b/src/Currency.php
@@ -20,7 +20,7 @@ final readonly class Currency implements Stringable, JsonSerializable
      *                                                uppercase ISO 4217 currency code. For non-ISO currencies no
      *                                                constraints are defined, but the code must be unique across an
      *                                                application and must not conflict with ISO currency codes.
-     * @param int              $numericCode           The numeric currency code. For ISO currencies this will be the
+     * @param non-negative-int $numericCode           The numeric currency code. For ISO currencies this will be the
      *                                                ISO 4217 numeric currency code, without leading zeros. For non-ISO
      *                                                currencies no constraints are defined, but the code must be unique
      *                                                across an application and must not conflict with ISO currency codes.
@@ -109,6 +109,8 @@ final readonly class Currency implements Stringable, JsonSerializable
      *
      * For ISO currencies this will be the ISO 4217 numeric currency code, without leading zeros.
      * For non ISO currencies no constraints are defined.
+     *
+     * @return non-negative-int
      */
     public function getNumericCode(): int
     {

--- a/src/IsoCurrencyProvider.php
+++ b/src/IsoCurrencyProvider.php
@@ -20,7 +20,7 @@ final class IsoCurrencyProvider
     /**
      * The raw currency data, indexed by currency code.
      *
-     * @var array<string, array{string, int, string, non-negative-int, CurrencyType}>
+     * @var array<string, array{string, non-negative-int, string, non-negative-int, CurrencyType}>
      */
     private readonly array $currencyData;
 

--- a/src/Money.php
+++ b/src/Money.php
@@ -511,7 +511,7 @@ final readonly class Money extends AbstractMoney
      *
      * The resulting monies have the same context as this Money.
      *
-     * @param int[] $ratios The ratios.
+     * @param non-negative-int[] $ratios The ratios.
      *
      * @return Money[]
      *
@@ -524,6 +524,7 @@ final readonly class Money extends AbstractMoney
         }
 
         foreach ($ratios as $ratio) {
+            /** @psalm-suppress DocblockTypeContradiction */
             if ($ratio < 0) {
                 throw new InvalidArgumentException('Cannot allocate() negative ratios.');
             }
@@ -576,7 +577,7 @@ final readonly class Money extends AbstractMoney
      *
      * The resulting monies have the same context as this Money.
      *
-     * @param int[] $ratios The ratios.
+     * @param non-negative-int[] $ratios The ratios.
      *
      * @return Money[]
      *
@@ -589,6 +590,7 @@ final readonly class Money extends AbstractMoney
         }
 
         foreach ($ratios as $ratio) {
+            /** @psalm-suppress DocblockTypeContradiction */
             if ($ratio < 0) {
                 throw new InvalidArgumentException('Cannot allocateWithRemainder() negative ratios.');
             }
@@ -628,7 +630,7 @@ final readonly class Money extends AbstractMoney
      *
      * The resulting monies have the same context as this Money.
      *
-     * @param int $parts The number of parts.
+     * @param positive-int $parts The number of parts.
      *
      * @return Money[]
      *
@@ -636,6 +638,7 @@ final readonly class Money extends AbstractMoney
      */
     public function split(int $parts): array
     {
+        /** @psalm-suppress DocblockTypeContradiction */
         if ($parts < 1) {
             throw new InvalidArgumentException('Cannot split() into less than 1 part.');
         }
@@ -651,7 +654,7 @@ final readonly class Money extends AbstractMoney
      *
      * The resulting monies have the same context as this Money.
      *
-     * @param int $parts The number of parts.
+     * @param positive-int $parts The number of parts.
      *
      * @return Money[]
      *
@@ -659,6 +662,7 @@ final readonly class Money extends AbstractMoney
      */
     public function splitWithRemainder(int $parts): array
     {
+        /** @psalm-suppress DocblockTypeContradiction */
         if ($parts < 1) {
             throw new InvalidArgumentException('Cannot splitWithRemainder() into less than 1 part.');
         }

--- a/src/MoneyComparator.php
+++ b/src/MoneyComparator.php
@@ -36,7 +36,7 @@ final readonly class MoneyComparator
      * This order is important if the exchange rate provider uses different exchange rates
      * when converting back and forth two currencies.
      *
-     * @return int -1, 0 or 1.
+     * @return -1|0|1
      *
      * @throws CurrencyConversionException If the exchange rate is not available.
      */


### PR DESCRIPTION
`src/AbstractMoney.php`
- `getSign()`: `@return int` → `@return -1|0|1`
- `compareTo()`: `@return int` → `@return -1|0|1`

`src/Context.php`
- `getStep()`: `@return int<1, max>` → `@return positive-int`

`src/Context/CashContext.php`
- `$step` param: `int<1, max>` → `positive-int`

`src/Context/CustomContext.php`
- `$step` param: `int<1, max>` → `positive-int`
- `isValidStepForScale()` `$step` param: `int<1, max>` → `positive-int`
- `getScale()`: added `@return non-negative-int`

`src/Currency.php`
- `$numericCode` param: `int` → `non-negative-int`
- Added `@psalm-suppress DocblockTypeContradiction` on `$defaultFractionDigits < 0` guard

`src/IsoCurrencyProvider.php`
- `$currencyData` array: narrowed `$numericCode` position from `int` to `non-negative-int`

`src/Money.php`
- `allocate()` `$ratios`: `int[]` → `non-negative-int[]`, added `@psalm-suppress` on `$ratio < 0` guard
- `allocateWithRemainder()` `$ratios`: `int[]` → `non-negative-int[]`, added `@psalm-suppress` on `$ratio < 0` guard
- `split()` `$parts`: `int` → `positive-int`, added `@psalm-suppress` on `$parts < 1` guard
- `splitWithRemainder()` `$parts`: `int` → `positive-int`, added `@psalm-suppress` on `$parts < 1` guard

`src/MoneyComparator.php`
- `compare()`: `@return int` → `@return -1|0|1`

like https://github.com/brick/math/pull/108