### PR TITLE
feat: narrow `@throws` types and add PHPStan dynamic throw type extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,6 +490,21 @@ If you're using an ORM such as Doctrine, it is advised to store the amount and c
   }
   ```
 
+## PHPStan extensions
+
+This library ships with PHPStan extensions that narrow throw types based on argument types.
+For example, PHPStan will know that `Money::of(100, 'USD')` cannot throw `UnknownCurrencyException`, or that
+`dividedBy($int, RoundingMode::Down)` can only throw `DivisionByZeroException`.
+
+If you use [`phpstan/extension-installer`](https://github.com/phpstan/extension-installer), the extension is registered automatically.
+
+Otherwise, include `phpstan/extension.neon` in your PHPStan configuration:
+
+```neon
+includes:
+    - vendor/brick/money/phpstan/extension.neon
+```
+
 ## FAQ
 
 > How does this project compare with [moneyphp/money](https://github.com/moneyphp/money)?

--- a/composer.json
+++ b/composer.json
@@ -24,12 +24,20 @@
     },
     "autoload": {
         "psr-4": {
-            "Brick\\Money\\": "src/"
+            "Brick\\Money\\": "src/",
+            "Brick\\Money\\PHPStan\\": "phpstan/"
         }
     },
     "autoload-dev": {
         "psr-4": {
             "Brick\\Money\\Tests\\": "tests/"
+        }
+    },
+    "extra": {
+        "phpstan": {
+            "includes": [
+                "phpstan/extension.neon"
+            ]
         }
     },
     "config": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,11 @@
+includes:
+    - phpstan/extension.neon
+
 parameters:
     level: 10
     paths:
         - src
+        - phpstan
     ignoreErrors:
         # Methods that return void are considered impure.
         # https://phpstan.org/blog/remembering-and-forgetting-returned-values

--- a/phpstan/CurrencyConverterThrowTypeExtension.php
+++ b/phpstan/CurrencyConverterThrowTypeExtension.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brick\Money\PHPStan;
+
+use Brick\Math\Exception\RoundingNecessaryException;
+use Brick\Money\CurrencyConverter;
+use Brick\Money\Exception\CurrencyConversionException;
+use Brick\Money\Exception\UnknownCurrencyException;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicMethodThrowTypeExtension;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+
+/**
+ * Narrows the throw type of {@see CurrencyConverter::convert()} and {@see CurrencyConverter::convertToRational()}.
+ *
+ * - When the currency is a `Currency` instance or a known ISO code, {@see UnknownCurrencyException} cannot occur.
+ * - When the rounding mode is not `Unnecessary`, {@see RoundingNecessaryException} cannot occur.
+ */
+final class CurrencyConverterThrowTypeExtension implements DynamicMethodThrowTypeExtension
+{
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        $className = $methodReflection->getDeclaringClass()->getName();
+        $methodName = $methodReflection->getName();
+
+        return $className === CurrencyConverter::class
+            && ($methodName === 'convert' || $methodName === 'convertToRational');
+    }
+
+    public function getThrowTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope,
+    ): ?Type {
+        $args = $methodCall->getArgs();
+
+        if (! isset($args[1])) {
+            return $methodReflection->getThrowType();
+        }
+
+        $methodName = $methodReflection->getName();
+        $currencyType = $scope->getType($args[1]->value);
+        $currencyIsSafe = SafeType::isSafeCurrency($currencyType);
+
+        // Check rounding mode for convert() — arg index 3.
+        $roundingModeIsSafe = false;
+
+        if ($methodName === 'convert' && isset($args[3])) {
+            $roundingModeIsSafe = SafeType::isSafeRoundingMode($scope->getType($args[3]->value));
+        }
+
+        if (! $currencyIsSafe && ! $roundingModeIsSafe) {
+            return $methodReflection->getThrowType();
+        }
+
+        $residualTypes = [new ObjectType(CurrencyConversionException::class)];
+
+        if (! $currencyIsSafe) {
+            $residualTypes[] = new ObjectType(UnknownCurrencyException::class);
+        }
+
+        if ($methodName === 'convert' && ! $roundingModeIsSafe) {
+            $residualTypes[] = new ObjectType(RoundingNecessaryException::class);
+        }
+
+        return TypeCombinator::union(...$residualTypes);
+    }
+}

--- a/phpstan/MoneyFactoryRoundingModeThrowTypeExtension.php
+++ b/phpstan/MoneyFactoryRoundingModeThrowTypeExtension.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brick\Money\PHPStan;
+
+use Brick\Math\Exception\NumberFormatException;
+use Brick\Money\Exception\UnknownCurrencyException;
+use Brick\Money\Money;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicStaticMethodThrowTypeExtension;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+
+/**
+ * Narrows the throw type of {@see Money::of()} and {@see Money::ofMinor()} based on the {@see RoundingMode} parameter.
+ *
+ * When the rounding mode is known to NOT be `Unnecessary`, {@see RoundingNecessaryException} cannot occur.
+ */
+final class MoneyFactoryRoundingModeThrowTypeExtension implements DynamicStaticMethodThrowTypeExtension
+{
+    /** method name => rounding mode arg index */
+    private const METHODS = [
+        'of' => 3,
+        'ofMinor' => 3,
+    ];
+
+    public function isStaticMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getDeclaringClass()->getName() === Money::class
+            && isset(self::METHODS[$methodReflection->getName()]);
+    }
+
+    public function getThrowTypeFromStaticMethodCall(
+        MethodReflection $methodReflection,
+        StaticCall $methodCall,
+        Scope $scope,
+    ): ?Type {
+        $methodName = $methodReflection->getName();
+        $roundingModeArgIndex = self::METHODS[$methodName];
+
+        $args = $methodCall->getArgs();
+
+        if (! isset($args[$roundingModeArgIndex])) {
+            return $methodReflection->getThrowType();
+        }
+
+        $roundingModeType = $scope->getType($args[$roundingModeArgIndex]->value);
+
+        if (! SafeType::isSafeRoundingMode($roundingModeType)) {
+            return $methodReflection->getThrowType();
+        }
+
+        // Rounding mode is not Unnecessary — RoundingNecessaryException cannot occur.
+        return TypeCombinator::union(
+            new ObjectType(NumberFormatException::class),
+            new ObjectType(UnknownCurrencyException::class),
+        );
+    }
+}

--- a/phpstan/MoneyFactoryThrowTypeExtension.php
+++ b/phpstan/MoneyFactoryThrowTypeExtension.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brick\Money\PHPStan;
+
+use Brick\Math\Exception\NumberFormatException;
+use Brick\Math\Exception\RoundingNecessaryException;
+use Brick\Money\Exception\UnknownCurrencyException;
+use Brick\Money\Money;
+use Brick\Money\RationalMoney;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicStaticMethodThrowTypeExtension;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+
+use function count;
+use function in_array;
+
+/**
+ * Narrows the throw type of {@see Money::of()}, {@see Money::ofMinor()}, {@see Money::zero()},
+ * {@see RationalMoney::of()}, and {@see RationalMoney::zero()}.
+ *
+ * - When the amount is a `BigNumber`, `int`, or `numeric-string`, {@see NumberFormatException} from parsing cannot occur.
+ * - When the currency is a {@see Currency} instance or a known ISO currency code, {@see UnknownCurrencyException} cannot occur.
+ * - For `Money::of()`/`ofMinor()`, {@see RoundingNecessaryException} may still occur depending on the rounding mode.
+ */
+final class MoneyFactoryThrowTypeExtension implements DynamicStaticMethodThrowTypeExtension
+{
+    /** @var array<class-string, list<string>> */
+    private const SUPPORTED_METHODS = [
+        Money::class => ['of', 'ofMinor', 'zero'],
+        RationalMoney::class => ['of', 'zero'],
+    ];
+
+    public function isStaticMethodSupported(MethodReflection $methodReflection): bool
+    {
+        $className = $methodReflection->getDeclaringClass()->getName();
+        $methodName = $methodReflection->getName();
+
+        return isset(self::SUPPORTED_METHODS[$className])
+            && in_array($methodName, self::SUPPORTED_METHODS[$className], true);
+    }
+
+    public function getThrowTypeFromStaticMethodCall(
+        MethodReflection $methodReflection,
+        StaticCall $methodCall,
+        Scope $scope,
+    ): ?Type {
+        $args = $methodCall->getArgs();
+        $methodName = $methodReflection->getName();
+
+        // zero() only has a currency parameter.
+        if ($methodName === 'zero') {
+            return $this->narrowZero($methodCall, $scope, $methodReflection);
+        }
+
+        if (count($args) < 2) {
+            return $methodReflection->getThrowType();
+        }
+
+        $className = $methodReflection->getDeclaringClass()->getName();
+        $amountType = $scope->getType($args[0]->value);
+        $currencyType = $scope->getType($args[1]->value);
+
+        $amountIsSafe = SafeType::isSafeNumber($amountType);
+        $currencyIsSafe = SafeType::isSafeCurrency($currencyType);
+
+        if (! $amountIsSafe && ! $currencyIsSafe) {
+            return $methodReflection->getThrowType();
+        }
+
+        $residualTypes = [];
+
+        if (! $amountIsSafe) {
+            $residualTypes[] = new ObjectType(NumberFormatException::class);
+        }
+
+        if (! $currencyIsSafe) {
+            $residualTypes[] = new ObjectType(UnknownCurrencyException::class);
+        }
+
+        // Money::of()/ofMinor() can still throw RoundingNecessaryException.
+        if ($className === Money::class) {
+            $residualTypes[] = new ObjectType(RoundingNecessaryException::class);
+        }
+
+        if ($residualTypes === []) {
+            return null;
+        }
+
+        return TypeCombinator::union(...$residualTypes);
+    }
+
+    private function narrowZero(
+        StaticCall $methodCall,
+        Scope $scope,
+        MethodReflection $methodReflection,
+    ): ?Type {
+        $args = $methodCall->getArgs();
+
+        if (count($args) < 1) {
+            return $methodReflection->getThrowType();
+        }
+
+        $currencyType = $scope->getType($args[0]->value);
+
+        if (SafeType::isSafeCurrency($currencyType)) {
+            return null;
+        }
+
+        return $methodReflection->getThrowType();
+    }
+}

--- a/phpstan/MoneyOperationThrowTypeExtension.php
+++ b/phpstan/MoneyOperationThrowTypeExtension.php
@@ -1,0 +1,270 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brick\Money\PHPStan;
+
+use Brick\Math\Exception\DivisionByZeroException;
+use Brick\Math\Exception\NumberFormatException;
+use Brick\Math\Exception\RoundingNecessaryException;
+use Brick\Money\AbstractMoney;
+use Brick\Money\Exception\MoneyMismatchException;
+use Brick\Money\Exception\UnknownCurrencyException;
+use Brick\Money\Money;
+use Brick\Money\MoneyBag;
+use Brick\Money\RationalMoney;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicMethodThrowTypeExtension;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+
+use function count;
+use function in_array;
+
+/**
+ * Narrows the throw type of {@see Money}, {@see RationalMoney}, and {@see MoneyBag} instance methods
+ * based on argument types and rounding mode.
+ *
+ * - When the argument is an {@see AbstractMoney}, {@see NumberFormatException} from parsing cannot occur.
+ * - When the argument is a `BigNumber`, `int`, or `numeric-string`, parsing cannot throw and there is no currency check.
+ * - When the rounding mode is known to NOT be `Unnecessary`, {@see RoundingNecessaryException} cannot occur.
+ * - {@see RationalMoney} operations do not involve rounding, so narrowing eliminates all throws.
+ */
+final class MoneyOperationThrowTypeExtension implements DynamicMethodThrowTypeExtension
+{
+    private const COMPARISON_METHODS = [
+        'compareTo',
+        'isEqualTo',
+        'isLessThan',
+        'isLessThanOrEqualTo',
+        'isGreaterThan',
+        'isGreaterThanOrEqualTo',
+    ];
+
+    private const ARITHMETIC_METHODS = [
+        'plus',
+        'minus',
+        'multipliedBy',
+        'dividedBy',
+    ];
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        $methodName = $methodReflection->getName();
+        $className = $methodReflection->getDeclaringClass()->getName();
+
+        if (in_array($methodName, self::COMPARISON_METHODS, true)) {
+            return $className === AbstractMoney::class
+                || $methodReflection->getDeclaringClass()->isSubclassOf(AbstractMoney::class);
+        }
+
+        $isAbstractMoney = $className === AbstractMoney::class
+            || $methodReflection->getDeclaringClass()->isSubclassOf(AbstractMoney::class);
+
+        if (in_array($methodName, self::ARITHMETIC_METHODS, true)) {
+            return $isAbstractMoney;
+        }
+
+        if ($methodName === 'convertedTo') {
+            return $className === RationalMoney::class;
+        }
+
+        if ($methodName === 'getMoney') {
+            return $className === MoneyBag::class;
+        }
+
+        return false;
+    }
+
+    public function getThrowTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope,
+    ): ?Type {
+        if ($methodCall->getArgs() === []) {
+            return $methodReflection->getThrowType();
+        }
+
+        $methodName = $methodReflection->getName();
+
+        if ($methodName === 'convertedTo') {
+            return $this->narrowConvertedTo($methodCall, $scope, $methodReflection);
+        }
+
+        if ($methodName === 'getMoney') {
+            return $this->narrowGetMoney($methodCall, $scope, $methodReflection);
+        }
+
+        if (in_array($methodName, self::COMPARISON_METHODS, true)) {
+            return $this->narrowComparison($methodCall, $scope, $methodReflection);
+        }
+
+        return $this->narrowArithmetic($methodName, $methodCall, $scope, $methodReflection);
+    }
+
+    /**
+     * Narrows comparison methods on {@see AbstractMoney}.
+     *
+     * AbstractMoney arg → only {@see MoneyMismatchException}; safe number → no throw.
+     */
+    private function narrowComparison(
+        MethodCall $methodCall,
+        Scope $scope,
+        MethodReflection $methodReflection,
+    ): ?Type {
+        $argType = $scope->getType($methodCall->getArgs()[0]->value);
+
+        if ((new ObjectType(AbstractMoney::class))->isSuperTypeOf($argType)->yes()) {
+            return new ObjectType(MoneyMismatchException::class);
+        }
+
+        if (SafeType::isSafeNumber($argType)) {
+            return null;
+        }
+
+        return $methodReflection->getThrowType();
+    }
+
+    /**
+     * Narrows arithmetic methods (`plus`, `minus`, `multipliedBy`, `dividedBy`)
+     * on {@see Money} and {@see RationalMoney}.
+     *
+     * Considers both argument type (safe number / {@see AbstractMoney}) and rounding mode.
+     */
+    private function narrowArithmetic(
+        string $methodName,
+        MethodCall $methodCall,
+        Scope $scope,
+        MethodReflection $methodReflection,
+    ): ?Type {
+        $callerType = $scope->getType($methodCall->var);
+        $isRational = (new ObjectType(RationalMoney::class))->isSuperTypeOf($callerType)->yes();
+
+        $args = $methodCall->getArgs();
+        $argType = $scope->getType($args[0]->value);
+
+        $argIsSafeNumber = SafeType::isSafeNumber($argType);
+        $argIsAbstractMoney = (new ObjectType(AbstractMoney::class))->isSuperTypeOf($argType)->yes();
+        $argIsSafe = $argIsSafeNumber || $argIsAbstractMoney;
+
+        $roundingModeIsSafe = false;
+
+        if (! $isRational && isset($args[1])) {
+            $roundingModeIsSafe = SafeType::isSafeRoundingMode($scope->getType($args[1]->value));
+        }
+
+        if (! $argIsSafe && ! $roundingModeIsSafe) {
+            return $methodReflection->getThrowType();
+        }
+
+        // RationalMoney: no rounding concern. Safe arg → no throw (except dividedBy zero).
+        if ($isRational) {
+            if ($argIsAbstractMoney) {
+                $residual = [new ObjectType(MoneyMismatchException::class)];
+
+                if ($methodName === 'dividedBy' && ! SafeType::isNonZero($argType)) {
+                    $residual[] = new ObjectType(DivisionByZeroException::class);
+                }
+
+                return TypeCombinator::union(...$residual);
+            }
+
+            if ($argIsSafeNumber) {
+                if ($methodName === 'dividedBy' && ! SafeType::isNonZero($argType)) {
+                    return new ObjectType(DivisionByZeroException::class);
+                }
+
+                return null;
+            }
+
+            return $methodReflection->getThrowType();
+        }
+
+        // Money: build residual throw types.
+        $residualTypes = [];
+
+        // MoneyMismatchException when arg is AbstractMoney (currency/context mismatch).
+        if ($argIsAbstractMoney) {
+            $residualTypes[] = new ObjectType(MoneyMismatchException::class);
+        }
+
+        // NumberFormatException when arg is not safe (parsing risk).
+        if (! $argIsSafe) {
+            $residualTypes[] = new ObjectType(NumberFormatException::class);
+        }
+
+        // RoundingNecessaryException when rounding mode is not safe.
+        if (! $roundingModeIsSafe) {
+            $residualTypes[] = new ObjectType(RoundingNecessaryException::class);
+        }
+
+        // DivisionByZeroException when divisor could be zero.
+        if ($methodName === 'dividedBy' && ! SafeType::isNonZero($argType)) {
+            $residualTypes[] = new ObjectType(DivisionByZeroException::class);
+        }
+
+        if ($residualTypes === []) {
+            return null;
+        }
+
+        return TypeCombinator::union(...$residualTypes);
+    }
+
+    /**
+     * Narrows {@see MoneyBag::getMoney()} — safe currency eliminates {@see UnknownCurrencyException}.
+     */
+    private function narrowGetMoney(
+        MethodCall $methodCall,
+        Scope $scope,
+        MethodReflection $methodReflection,
+    ): ?Type {
+        $currencyType = $scope->getType($methodCall->getArgs()[0]->value);
+
+        if (SafeType::isSafeCurrency($currencyType)) {
+            return null;
+        }
+
+        return $methodReflection->getThrowType();
+    }
+
+    /**
+     * Narrows {@see RationalMoney::convertedTo()} based on currency and exchange rate argument types.
+     */
+    private function narrowConvertedTo(
+        MethodCall $methodCall,
+        Scope $scope,
+        MethodReflection $methodReflection,
+    ): ?Type {
+        $args = $methodCall->getArgs();
+
+        if (count($args) < 2) {
+            return $methodReflection->getThrowType();
+        }
+
+        $currencyIsSafe = SafeType::isSafeCurrency($scope->getType($args[0]->value));
+        $rateIsSafe = SafeType::isSafeNumber($scope->getType($args[1]->value));
+
+        if (! $currencyIsSafe && ! $rateIsSafe) {
+            return $methodReflection->getThrowType();
+        }
+
+        $residualTypes = [];
+
+        if (! $currencyIsSafe) {
+            $residualTypes[] = new ObjectType(UnknownCurrencyException::class);
+        }
+
+        if (! $rateIsSafe) {
+            $residualTypes[] = new ObjectType(NumberFormatException::class);
+        }
+
+        if ($residualTypes === []) {
+            return null;
+        }
+
+        return TypeCombinator::union(...$residualTypes);
+    }
+}

--- a/phpstan/MoneyRoundingModeThrowTypeExtension.php
+++ b/phpstan/MoneyRoundingModeThrowTypeExtension.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brick\Money\PHPStan;
+
+use Brick\Math\Exception\NumberFormatException;
+use Brick\Money\AbstractMoney;
+use Brick\Money\Exception\UnknownCurrencyException;
+use Brick\Money\Money;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicMethodThrowTypeExtension;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+
+/**
+ * Narrows the throw type of {@see Money::toContext()} and {@see Money::convertedTo()}
+ * based on the {@see RoundingMode} parameter.
+ *
+ * When the rounding mode is known to NOT be `Unnecessary`, {@see RoundingNecessaryException} cannot occur.
+ */
+final class MoneyRoundingModeThrowTypeExtension implements DynamicMethodThrowTypeExtension
+{
+    /**
+     * method name => rounding mode arg index.
+     *
+     * @var array<string, int>
+     */
+    private const METHODS = [
+        'toContext' => 1,
+        'convertedTo' => 3,
+    ];
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        $methodName = $methodReflection->getName();
+        $className = $methodReflection->getDeclaringClass()->getName();
+
+        if (! isset(self::METHODS[$methodName])) {
+            return false;
+        }
+
+        return $className === Money::class
+            || $className === AbstractMoney::class
+            || $methodReflection->getDeclaringClass()->isSubclassOf(AbstractMoney::class);
+    }
+
+    public function getThrowTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope,
+    ): ?Type {
+        $methodName = $methodReflection->getName();
+        $roundingModeArgIndex = self::METHODS[$methodName];
+
+        $args = $methodCall->getArgs();
+
+        if (! isset($args[$roundingModeArgIndex])) {
+            return $methodReflection->getThrowType();
+        }
+
+        $roundingModeType = $scope->getType($args[$roundingModeArgIndex]->value);
+
+        if (! SafeType::isSafeRoundingMode($roundingModeType)) {
+            return $methodReflection->getThrowType();
+        }
+
+        // Rounding mode is not Unnecessary — RoundingNecessaryException cannot occur.
+        if ($methodName === 'toContext') {
+            return null;
+        }
+
+        // convertedTo: UnknownCurrencyException + NumberFormatException remain.
+        return TypeCombinator::union(
+            new ObjectType(UnknownCurrencyException::class),
+            new ObjectType(NumberFormatException::class),
+        );
+    }
+}

--- a/phpstan/SafeType.php
+++ b/phpstan/SafeType.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brick\Money\PHPStan;
+
+use Brick\Math\BigNumber;
+use Brick\Math\RoundingMode;
+use Brick\Money\Currency;
+use PHPStan\Type\Accessory\AccessoryNumericStringType;
+use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\Enum\EnumCaseObjectType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\IntersectionType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
+
+/**
+ * Helpers for checking whether argument types are safe to pass without risk of exceptions.
+ */
+final class SafeType
+{
+    private static ?Type $safeNumberType = null;
+
+    /** @var array<string, true>|null */
+    private static ?array $knownCurrencies = null;
+
+    /**
+     * Returns whether the given type can be safely passed to {@see BigNumber::of()} without risk of parsing exceptions.
+     *
+     * Safe types: `BigNumber` (and subclasses), `int`, `numeric-string`.
+     */
+    public static function isSafeNumber(Type $type): bool
+    {
+        return self::getSafeNumberType()->isSuperTypeOf($type)->yes();
+    }
+
+    /**
+     * Returns whether the given type is a known currency that cannot throw {@see UnknownCurrencyException}.
+     *
+     * This is true when the type is a {@see Currency} instance, or a constant string matching a known ISO currency code.
+     */
+    public static function isSafeCurrency(Type $type): bool
+    {
+        if ((new ObjectType(Currency::class))->isSuperTypeOf($type)->yes()) {
+            return true;
+        }
+
+        $constantStrings = $type->getConstantStrings();
+
+        if ($constantStrings === []) {
+            return false;
+        }
+
+        $knownCurrencies = self::getKnownCurrencies();
+
+        foreach ($constantStrings as $constantString) {
+            if (! isset($knownCurrencies[$constantString->getValue()])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns whether the given rounding mode type is known to NOT be `Unnecessary`,
+     * meaning {@see RoundingNecessaryException} cannot occur.
+     */
+    public static function isSafeRoundingMode(Type $type): bool
+    {
+        $unnecessaryType = new EnumCaseObjectType(RoundingMode::class, 'Unnecessary');
+
+        return $unnecessaryType->isSuperTypeOf($type)->no();
+    }
+
+    /**
+     * Returns whether the given type is guaranteed to be non-zero.
+     *
+     * This is used to eliminate {@see DivisionByZeroException} from throw types.
+     * Only proven for integer types (e.g. int<1, max>, literal 5).
+     */
+    public static function isNonZero(Type $type): bool
+    {
+        if (! (new IntegerType())->isSuperTypeOf($type)->yes()) {
+            return false;
+        }
+
+        $zeroType = new ConstantIntegerType(0);
+
+        return $zeroType->isSuperTypeOf($type)->no();
+    }
+
+    private static function getSafeNumberType(): Type
+    {
+        return self::$safeNumberType ??= new UnionType([
+            new ObjectType(BigNumber::class),
+            new IntegerType(),
+            new IntersectionType([new StringType(), new AccessoryNumericStringType()]),
+        ]);
+    }
+
+    /**
+     * @return array<string, true>
+     */
+    private static function getKnownCurrencies(): array
+    {
+        if (self::$knownCurrencies === null) {
+            /** @var array<string, mixed> $data */
+            $data = require __DIR__ . '/../data/iso-currencies.php';
+            self::$knownCurrencies = [];
+
+            foreach ($data as $code => $_) {
+                self::$knownCurrencies[$code] = true;
+            }
+        }
+
+        return self::$knownCurrencies;
+    }
+}

--- a/phpstan/extension.neon
+++ b/phpstan/extension.neon
@@ -1,0 +1,25 @@
+services:
+	-
+		class: Brick\Money\PHPStan\MoneyFactoryThrowTypeExtension
+		tags:
+			- phpstan.dynamicStaticMethodThrowTypeExtension
+
+	-
+		class: Brick\Money\PHPStan\MoneyFactoryRoundingModeThrowTypeExtension
+		tags:
+			- phpstan.dynamicStaticMethodThrowTypeExtension
+
+	-
+		class: Brick\Money\PHPStan\MoneyOperationThrowTypeExtension
+		tags:
+			- phpstan.dynamicMethodThrowTypeExtension
+
+	-
+		class: Brick\Money\PHPStan\MoneyRoundingModeThrowTypeExtension
+		tags:
+			- phpstan.dynamicMethodThrowTypeExtension
+
+	-
+		class: Brick\Money\PHPStan\CurrencyConverterThrowTypeExtension
+		tags:
+			- phpstan.dynamicMethodThrowTypeExtension

--- a/src/AbstractMoney.php
+++ b/src/AbstractMoney.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Brick\Money;
 
 use Brick\Math\BigNumber;
-use Brick\Math\Exception\MathException;
+use Brick\Math\Exception\NumberFormatException;
 use Brick\Math\Exception\RoundingNecessaryException;
 use Brick\Math\RoundingMode;
 use Brick\Money\Exception\MoneyMismatchException;
@@ -153,7 +153,7 @@ abstract readonly class AbstractMoney implements Monetary, Stringable, JsonSeria
      *
      * @return -1|0|1 If `$this` is less than, equal to, or greater than `$that`.
      *
-     * @throws MathException          If the argument is an invalid number.
+     * @throws NumberFormatException  If the argument is not a valid number.
      * @throws MoneyMismatchException If the argument is a money in a different currency.
      *
      * @pure
@@ -166,7 +166,7 @@ abstract readonly class AbstractMoney implements Monetary, Stringable, JsonSeria
     /**
      * Returns whether this money is equal to the given amount.
      *
-     * @throws MathException          If the argument is an invalid number.
+     * @throws NumberFormatException  If the argument is not a valid number.
      * @throws MoneyMismatchException If the argument is a money in a different currency.
      *
      * @pure
@@ -179,7 +179,7 @@ abstract readonly class AbstractMoney implements Monetary, Stringable, JsonSeria
     /**
      * Returns whether this money is less than the given amount.
      *
-     * @throws MathException          If the argument is an invalid number.
+     * @throws NumberFormatException  If the argument is not a valid number.
      * @throws MoneyMismatchException If the argument is a money in a different currency.
      *
      * @pure
@@ -192,7 +192,7 @@ abstract readonly class AbstractMoney implements Monetary, Stringable, JsonSeria
     /**
      * Returns whether this money is less than or equal to the given amount.
      *
-     * @throws MathException          If the argument is an invalid number.
+     * @throws NumberFormatException  If the argument is not a valid number.
      * @throws MoneyMismatchException If the argument is a money in a different currency.
      *
      * @pure
@@ -205,7 +205,7 @@ abstract readonly class AbstractMoney implements Monetary, Stringable, JsonSeria
     /**
      * Returns whether this money is greater than the given amount.
      *
-     * @throws MathException          If the argument is an invalid number.
+     * @throws NumberFormatException  If the argument is not a valid number.
      * @throws MoneyMismatchException If the argument is a money in a different currency.
      *
      * @pure
@@ -218,7 +218,7 @@ abstract readonly class AbstractMoney implements Monetary, Stringable, JsonSeria
     /**
      * Returns whether this money is greater than or equal to the given amount.
      *
-     * @throws MathException          If the argument is an invalid number.
+     * @throws NumberFormatException  If the argument is not a valid number.
      * @throws MoneyMismatchException If the argument is a money in a different currency.
      *
      * @pure

--- a/src/Money.php
+++ b/src/Money.php
@@ -8,7 +8,8 @@ use Brick\Math\BigDecimal;
 use Brick\Math\BigInteger;
 use Brick\Math\BigNumber;
 use Brick\Math\BigRational;
-use Brick\Math\Exception\MathException;
+use Brick\Math\Exception\DivisionByZeroException;
+use Brick\Math\Exception\NumberFormatException;
 use Brick\Math\Exception\RoundingNecessaryException;
 use Brick\Math\RoundingMode;
 use Brick\Money\Context\DefaultContext;
@@ -174,7 +175,7 @@ final readonly class Money extends AbstractMoney
      * @param Context|null         $context      An optional Context, defaults to DefaultContext.
      * @param RoundingMode         $roundingMode An optional RoundingMode, if the amount does not fit the context.
      *
-     * @throws MathException              If the amount is not a valid number.
+     * @throws NumberFormatException      If the amount is not a valid number.
      * @throws UnknownCurrencyException   If the currency is an unknown currency code.
      * @throws RoundingNecessaryException If the rounding mode is RoundingMode::Unnecessary, and rounding is necessary
      *                                    to represent the amount at the requested scale.
@@ -217,7 +218,7 @@ final readonly class Money extends AbstractMoney
      * @param Context|null         $context      An optional Context, defaults to DefaultContext.
      * @param RoundingMode         $roundingMode An optional RoundingMode, if the amount does not fit the context.
      *
-     * @throws MathException              If the amount is not a valid number.
+     * @throws NumberFormatException      If the amount is not a valid number.
      * @throws UnknownCurrencyException   If the currency is an unknown currency code.
      * @throws RoundingNecessaryException If the rounding mode is RoundingMode::Unnecessary, and rounding is necessary
      *                                    to represent the amount at the requested scale.
@@ -351,8 +352,9 @@ final readonly class Money extends AbstractMoney
      * @param AbstractMoney|BigNumber|int|string $that         The money or amount to add.
      * @param RoundingMode                       $roundingMode An optional RoundingMode constant.
      *
-     * @throws MathException          If the argument is an invalid number or rounding is necessary.
-     * @throws MoneyMismatchException If the argument is a money in a different currency or in a different context.
+     * @throws NumberFormatException      If the argument is not a valid number.
+     * @throws RoundingNecessaryException If the rounding mode is RoundingMode::Unnecessary, and rounding is necessary.
+     * @throws MoneyMismatchException     If the argument is a money in a different currency or in a different context.
      *
      * @pure
      */
@@ -387,8 +389,9 @@ final readonly class Money extends AbstractMoney
      * @param AbstractMoney|BigNumber|int|string $that         The money or amount to subtract.
      * @param RoundingMode                       $roundingMode An optional RoundingMode constant.
      *
-     * @throws MathException          If the argument is an invalid number or rounding is necessary.
-     * @throws MoneyMismatchException If the argument is a money in a different currency or in a different context.
+     * @throws NumberFormatException      If the argument is not a valid number.
+     * @throws RoundingNecessaryException If the rounding mode is RoundingMode::Unnecessary, and rounding is necessary.
+     * @throws MoneyMismatchException     If the argument is a money in a different currency or in a different context.
      *
      * @pure
      */
@@ -419,7 +422,8 @@ final readonly class Money extends AbstractMoney
      * @param BigNumber|int|string $that         The multiplier.
      * @param RoundingMode         $roundingMode An optional RoundingMode constant.
      *
-     * @throws MathException If the argument is an invalid number or rounding is necessary.
+     * @throws NumberFormatException      If the argument is not a valid number.
+     * @throws RoundingNecessaryException If the rounding mode is RoundingMode::Unnecessary, and rounding is necessary.
      *
      * @pure
      */
@@ -440,7 +444,9 @@ final readonly class Money extends AbstractMoney
      * @param BigNumber|int|string $that         The divisor.
      * @param RoundingMode         $roundingMode An optional RoundingMode constant.
      *
-     * @throws MathException If the argument is an invalid number or is zero, or rounding is necessary.
+     * @throws NumberFormatException      If the argument is not a valid number.
+     * @throws DivisionByZeroException    If the divisor is zero.
+     * @throws RoundingNecessaryException If the rounding mode is RoundingMode::Unnecessary, and rounding is necessary.
      *
      * @pure
      */
@@ -459,7 +465,9 @@ final readonly class Money extends AbstractMoney
      *
      * @param BigNumber|int|string $that The divisor. Must be convertible to a BigInteger.
      *
-     * @throws MathException If the divisor cannot be converted to a BigInteger.
+     * @throws NumberFormatException      If the divisor is not a valid number.
+     * @throws RoundingNecessaryException If the divisor is not convertible to a BigInteger.
+     * @throws DivisionByZeroException    If the divisor is zero.
      *
      * @pure
      */
@@ -487,7 +495,9 @@ final readonly class Money extends AbstractMoney
      *
      * @return array{Money, Money} The quotient and the remainder.
      *
-     * @throws MathException If the divisor cannot be converted to a BigInteger.
+     * @throws NumberFormatException      If the divisor is not a valid number.
+     * @throws RoundingNecessaryException If the divisor is not convertible to a BigInteger.
+     * @throws DivisionByZeroException    If the divisor is zero.
      *
      * @pure
      */
@@ -726,8 +736,9 @@ final readonly class Money extends AbstractMoney
      * @param Context|null         $context      An optional context, defaults to DefaultContext.
      * @param RoundingMode         $roundingMode An optional rounding mode.
      *
-     * @throws UnknownCurrencyException If an unknown currency code is given.
-     * @throws MathException            If the exchange rate or rounding mode is invalid, or rounding is necessary.
+     * @throws UnknownCurrencyException   If an unknown currency code is given.
+     * @throws NumberFormatException      If the exchange rate is not a valid number.
+     * @throws RoundingNecessaryException If the rounding mode is RoundingMode::Unnecessary, and rounding is necessary.
      *
      * @pure
      */

--- a/src/RationalMoney.php
+++ b/src/RationalMoney.php
@@ -6,7 +6,8 @@ namespace Brick\Money;
 
 use Brick\Math\BigNumber;
 use Brick\Math\BigRational;
-use Brick\Math\Exception\MathException;
+use Brick\Math\Exception\DivisionByZeroException;
+use Brick\Math\Exception\NumberFormatException;
 use Brick\Money\Exception\MoneyMismatchException;
 use Brick\Money\Exception\UnknownCurrencyException;
 use Override;
@@ -41,7 +42,7 @@ final readonly class RationalMoney extends AbstractMoney
      * @param BigNumber|int|string $amount   The monetary amount.
      * @param Currency|string      $currency The Currency instance or ISO currency code.
      *
-     * @throws MathException            If the amount is not a valid number.
+     * @throws NumberFormatException    If the amount is not a valid number.
      * @throws UnknownCurrencyException If an unknown currency code is given.
      *
      * @pure
@@ -92,7 +93,7 @@ final readonly class RationalMoney extends AbstractMoney
      *
      * @param AbstractMoney|BigNumber|int|string $that The money or amount to add.
      *
-     * @throws MathException          If the argument is not a valid number.
+     * @throws NumberFormatException  If the argument is not a valid number.
      * @throws MoneyMismatchException If the argument is a money in another currency.
      *
      * @pure
@@ -110,7 +111,7 @@ final readonly class RationalMoney extends AbstractMoney
      *
      * @param AbstractMoney|BigNumber|int|string $that The money or amount to subtract.
      *
-     * @throws MathException          If the argument is not a valid number.
+     * @throws NumberFormatException  If the argument is not a valid number.
      * @throws MoneyMismatchException If the argument is a money in another currency.
      *
      * @pure
@@ -128,7 +129,7 @@ final readonly class RationalMoney extends AbstractMoney
      *
      * @param BigNumber|int|string $that The multiplier.
      *
-     * @throws MathException If the argument is not a valid number.
+     * @throws NumberFormatException If the argument is not a valid number.
      *
      * @pure
      */
@@ -144,7 +145,8 @@ final readonly class RationalMoney extends AbstractMoney
      *
      * @param BigNumber|int|string $that The divisor.
      *
-     * @throws MathException If the argument is not a valid number.
+     * @throws NumberFormatException   If the argument is not a valid number.
+     * @throws DivisionByZeroException If the divisor is zero.
      *
      * @pure
      */
@@ -182,7 +184,7 @@ final readonly class RationalMoney extends AbstractMoney
      * @param BigNumber|int|string $exchangeRate The exchange rate to multiply by.
      *
      * @throws UnknownCurrencyException If an unknown currency code is given.
-     * @throws MathException            If the exchange rate is not a valid number.
+     * @throws NumberFormatException    If the exchange rate is not a valid number.
      *
      * @pure
      */


### PR DESCRIPTION
Replaces broad `@throws MathException` with specific exceptions
(`NumberFormatException`, `RoundingNecessaryException`, `DivisionByZeroException`)
across `Money`, `RationalMoney`, and `AbstractMoney`.

Adds PHPStan extensions that narrow throw types based on argument types,
eliminating impossible exceptions at static analysis time.

Extensions:

- `MoneyFactoryThrowTypeExtension` — narrows `Money::of()`, `Money::ofMinor()`,
  `Money::zero()`, `RationalMoney::of()`, `RationalMoney::zero()`:
  - `BigNumber`|`int`|`numeric-string` amount → no `NumberFormatException`
  - `Currency` instance or known ISO code (`'USD'`, `'EUR'`, …) → no `UnknownCurrencyException`

- `MoneyFactoryRoundingModeThrowTypeExtension` — narrows `Money::of()`, `Money::ofMinor()`:
  - Non-`Unnecessary` rounding mode → no `RoundingNecessaryException`

- `MoneyOperationThrowTypeExtension` — narrows comparison methods, arithmetic
  operations on `Money` and `RationalMoney`, `convertedTo()`, `MoneyBag::getMoney()`:
  - `AbstractMoney` arg → only `MoneyMismatchException`
  - `BigNumber`|`int`|`numeric-string` arg → eliminates `NumberFormatException`
  - Safe rounding mode → eliminates `RoundingNecessaryException`
  - Non-zero integer divisor (e.g. `int<1, max>`) → eliminates `DivisionByZeroException`
  - Combined: e.g. `Money::dividedBy(int<1, max>, RoundingMode::Down)` → no throw
  - `MoneyBag::getMoney()` with safe currency → no throw

- `MoneyRoundingModeThrowTypeExtension` — narrows `toContext()`, `convertedTo()` on `Money`:
  - Non-`Unnecessary` rounding mode → no `RoundingNecessaryException`

- `CurrencyConverterThrowTypeExtension` — narrows `CurrencyConverter::convert()`
  and `CurrencyConverter::convertToRational()`:
  - `Currency` instance or known ISO code → no `UnknownCurrencyException`
  - Non-`Unnecessary` rounding mode → no `RoundingNecessaryException`

- `SafeType` — shared helper for safe number, safe currency, safe rounding mode,
  and non-zero divisor checks