### PR TITLE
Allow brick/math 0.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ $b = Money::of(1, 'EUR');
 $a->plus($b); // CurrencyMismatchException
 ```
 
-If the result needs rounding, a [rounding mode](https://github.com/brick/math/blob/0.17.0/src/RoundingMode.php) must be passed as second parameter, or an exception is thrown:
+If the result needs rounding, a [rounding mode](https://github.com/brick/math/blob/0.18.0/src/RoundingMode.php) must be passed as second parameter, or an exception is thrown:
 
 ```php
 use Brick\Money\Money;

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
-        "brick/math": "~0.15.0 || ~0.16.0 || ~0.17.0",
+        "brick/math": "~0.15.0 || ~0.16.0 || ~0.17.0 || ~0.18.0",
         "psr/simple-cache": "^2.0 || ^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
## Summary

`brick/math` 0.18.0 was recently released, but the current `composer.json` constraint (`~0.15.0 || ~0.16.0 || ~0.17.0`) excludes it, blocking installation of brick/money alongside brick/math 0.18.

This widens the constraint to allow `~0.18.0`.

## Compatibility

The breaking changes in brick/math 0.18 do not affect this library:
- `BigInteger::fromBytes()` parameter rename — only affects named-argument callers; not used here.
- Stricter `of()` parsing and exponent-overflow exception changes — no affected usage.
- Narrowed static-analysis return types — no impact.

## Verification (with brick/math 0.18.0 installed)

- PHPUnit: 935 tests, 1926 assertions — all passing.
- PHPStan: no errors.

Also updated the pinned `RoundingMode` link in the README from `0.17.0` to `0.18.0`.